### PR TITLE
Switch to semigroups Data.List.NonEmpty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ appendonly.aof
 *.prof
 /.hpc
 Main.hs
+/.cabal-sandbox/
+TAGS
+cabal.sandbox.config

--- a/benchmark/Benchmark.hs
+++ b/benchmark/Benchmark.hs
@@ -8,6 +8,7 @@ import Control.Monad.Trans
 import Data.Time
 import Database.Redis
 import Text.Printf
+import qualified Data.List.NonEmpty as LNE
 
 nRequests, nClients :: Int
 nRequests = 100000
@@ -22,8 +23,8 @@ main = do
     conn <- connect defaultConnectInfo
     runRedis conn $ do
         _ <- flushall
-        Right _ <- mset [ ("k1","v1"), ("k2","v2"), ("k3","v3")
-                        , ("k4","v4"), ("k5","v5") ]
+        Right _ <- mset (LNE.fromList [ ("k1","v1"), ("k2","v2"), ("k3","v3")
+                                      , ("k4","v4"), ("k5","v5") ])
     
         return ()
     
@@ -63,7 +64,7 @@ main = do
         return ()
     
     timeAction "mget" 1 $ do
-        Right vs <- mget ["k1","k2","k3","k4","k5"]
+        Right vs <- mget (LNE.fromList ["k1","k2","k3","k4","k5"])
         let expected = map Just ["v1","v2","v3","v4","v5"]
         True <- return $ vs == expected
         return ()

--- a/hedis.cabal
+++ b/hedis.cabal
@@ -83,7 +83,8 @@ benchmark hedis-benchmark
         base == 4.*,
         mtl == 2.*,
         hedis,
-        time >= 1.2
+        time >= 1.2,
+        semigroups >= 0.12.2 && < 0.13
     ghc-options: -O2 -Wall -rtsopts
     ghc-prof-options: -auto-all
 
@@ -98,7 +99,8 @@ test-suite hedis-test
         mtl == 2.*,
         test-framework,
         test-framework-hunit,
-        time
+        time,
+        semigroups >= 0.12.2 && < 0.13
     -- We use -O0 here, since GHC takes *very* long to compile so many constants
     ghc-options: -O0 -Wall -rtsopts -fno-warn-unused-do-bind
     ghc-prof-options: -auto-all

--- a/hedis.cabal
+++ b/hedis.cabal
@@ -1,5 +1,5 @@
 name:               hedis
-version:            0.6.5
+version:            0.7.0
 synopsis:
     Client library for the Redis datastore: supports full command set,  
     pipelining.
@@ -64,7 +64,8 @@ library
                     network == 2.*,
                     resource-pool == 0.2.*,
                     time,
-                    vector >= 0.9 && < 0.11
+                    vector >= 0.9 && < 0.11,
+                    semigroups >= 0.12.2 && < 0.13
 
   other-modules:    Database.Redis.Core,
                     Database.Redis.ProtocolPipelining,

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -197,33 +197,40 @@ strlen, -- |Get the length of the value stored in a key (<http://redis.io/comman
 
 import Prelude hiding (min,max)
 import Data.ByteString (ByteString)
+import Data.List.NonEmpty (NonEmpty(..))
+import Data.Semigroup ((<>), sconcat)
 import Database.Redis.ManualCommands
 import Database.Redis.Types
 import Database.Redis.Core
+import qualified Data.List.NonEmpty as LNE
 
 bgrewriteaof
     :: (RedisCtx m f)
     => m (f Status)
-bgrewriteaof  = sendRequest (["BGREWRITEAOF"] )
+bgrewriteaof  = sendRequest $ "BGREWRITEAOF" :| []
 
 sinter
     :: (RedisCtx m f)
-    => [ByteString] -- ^ key
+    => NonEmpty ByteString -- ^ key
     -> m (f [ByteString])
-sinter key = sendRequest (["SINTER"] ++ map encode key )
+sinter key = sendRequest $ ("SINTER" :| []) <> LNE.map encode key
 
 scriptExists
     :: (RedisCtx m f)
-    => [ByteString] -- ^ script
+    => NonEmpty ByteString -- ^ script
     -> m (f [Bool])
-scriptExists script = sendRequest (["SCRIPT","EXISTS"] ++ map encode script )
+scriptExists script = sendRequest $ ("SCRIPT" :| ["EXISTS"])
+                                    <> LNE.map encode script
 
 sunionstore
     :: (RedisCtx m f)
     => ByteString -- ^ destination
-    -> [ByteString] -- ^ key
+    -> NonEmpty ByteString -- ^ key
     -> m (f Integer)
-sunionstore destination key = sendRequest (["SUNIONSTORE"] ++ [encode destination] ++ map encode key )
+sunionstore destination key =
+    sendRequest (("SUNIONSTORE"
+                  :| [encode destination])
+                 <> LNE.map encode key)
 
 setex
     :: (RedisCtx m f)
@@ -231,19 +238,20 @@ setex
     -> Integer -- ^ seconds
     -> ByteString -- ^ value
     -> m (f Status)
-setex key seconds value = sendRequest (["SETEX"] ++ [encode key] ++ [encode seconds] ++ [encode value] )
+setex key seconds value =
+    sendRequest $ "SETEX" :| (encode key : encode seconds : encode value : [])
 
 hlen
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f Integer)
-hlen key = sendRequest (["HLEN"] ++ [encode key] )
+hlen key = sendRequest $ "HLEN" :| [encode key]
 
 scard
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f Integer)
-scard key = sendRequest (["SCARD"] ++ [encode key] )
+scard key = sendRequest $ "SCARD" :| [encode key]
 
 zremrangebyscore
     :: (RedisCtx m f)
@@ -251,49 +259,53 @@ zremrangebyscore
     -> Double -- ^ min
     -> Double -- ^ max
     -> m (f Integer)
-zremrangebyscore key min max = sendRequest (["ZREMRANGEBYSCORE"] ++ [encode key] ++ [encode min] ++ [encode max] )
+zremrangebyscore key min max =
+    sendRequest $ "ZREMRANGEBYSCORE"
+                  :| (encode key : encode min : encode max : [])
 
 rpushx
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> ByteString -- ^ value
     -> m (f Integer)
-rpushx key value = sendRequest (["RPUSHX"] ++ [encode key] ++ [encode value] )
+rpushx key value = sendRequest $ "RPUSHX" :| (encode key : encode value : [])
 
 spop
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f (Maybe ByteString))
-spop key = sendRequest (["SPOP"] ++ [encode key] )
+spop key = sendRequest $ "SPOP" :| [encode key]
 
 pttl
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f Integer)
-pttl key = sendRequest (["PTTL"] ++ [encode key] )
+pttl key = sendRequest $ "PTTL" :| [encode key]
 
 rpush
     :: (RedisCtx m f)
     => ByteString -- ^ key
-    -> [ByteString] -- ^ value
+    -> NonEmpty ByteString -- ^ value
     -> m (f Integer)
-rpush key value = sendRequest (["RPUSH"] ++ [encode key] ++ map encode value )
+rpush key value =
+    sendRequest $ ("RPUSH" :| [encode key])
+                  <> LNE.map encode value
 
 debugObject
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f ByteString)
-debugObject key = sendRequest (["DEBUG","OBJECT"] ++ [encode key] )
+debugObject key = sendRequest $ "DEBUG" :| ("OBJECT" : encode key : [])
 
 randomkey
     :: (RedisCtx m f)
     => m (f (Maybe ByteString))
-randomkey  = sendRequest (["RANDOMKEY"] )
+randomkey  = sendRequest $ "RANDOMKEY" :| []
 
 bgsave
     :: (RedisCtx m f)
     => m (f Status)
-bgsave  = sendRequest (["BGSAVE"] )
+bgsave  = sendRequest $ "BGSAVE" :| []
 
 getrange
     :: (RedisCtx m f)
@@ -301,7 +313,8 @@ getrange
     -> Integer -- ^ start
     -> Integer -- ^ end
     -> m (f ByteString)
-getrange key start end = sendRequest (["GETRANGE"] ++ [encode key] ++ [encode start] ++ [encode end] )
+getrange key start end =
+    sendRequest $ "GETRANGE" :| (encode key : encode start : encode end : [])
 
 zcount
     :: (RedisCtx m f)
@@ -309,21 +322,28 @@ zcount
     -> Double -- ^ min
     -> Double -- ^ max
     -> m (f Integer)
-zcount key min max = sendRequest (["ZCOUNT"] ++ [encode key] ++ [encode min] ++ [encode max] )
+zcount key min max =
+    sendRequest $ "ZCOUNT" :| (encode key : encode min : encode max : [])
 
 sdiffstore
     :: (RedisCtx m f)
     => ByteString -- ^ destination
-    -> [ByteString] -- ^ key
+    -> NonEmpty ByteString -- ^ key
     -> m (f Integer)
-sdiffstore destination key = sendRequest (["SDIFFSTORE"] ++ [encode destination] ++ map encode key )
+sdiffstore destination key =
+    sendRequest $ ("SDIFFSTORE"
+                   :| [encode destination])
+                  <> LNE.map encode key
 
 blpop
     :: (RedisCtx m f)
-    => [ByteString] -- ^ key
+    => NonEmpty ByteString -- ^ key
     -> Integer -- ^ timeout
     -> m (f (Maybe (ByteString,ByteString)))
-blpop key timeout = sendRequest (["BLPOP"] ++ map encode key ++ [encode timeout] )
+blpop key timeout =
+    sendRequest $ ("BLPOP" :| [])
+                  <> LNE.map encode key
+                  <> (encode timeout :| [])
 
 migrate
     :: (RedisCtx m f)
@@ -333,52 +353,58 @@ migrate
     -> Integer -- ^ destinationDb
     -> Integer -- ^ timeout
     -> m (f Status)
-migrate host port key destinationDb timeout = sendRequest (["MIGRATE"] ++ [encode host] ++ [encode port] ++ [encode key] ++ [encode destinationDb] ++ [encode timeout] )
+migrate host port key destinationDb timeout =
+    sendRequest $ "MIGRATE"
+                  :| (encode host : encode port : encode key :
+                      encode destinationDb : encode timeout : [])
 
 sismember
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> ByteString -- ^ member
     -> m (f Bool)
-sismember key member = sendRequest (["SISMEMBER"] ++ [encode key] ++ [encode member] )
+sismember key member =
+    sendRequest $ "SISMEMBER" :| (encode key : encode member : [])
 
 incr
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f Integer)
-incr key = sendRequest (["INCR"] ++ [encode key] )
+incr key = sendRequest $ "INCR" :| [encode key]
 
 hget
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> ByteString -- ^ field
     -> m (f (Maybe ByteString))
-hget key field = sendRequest (["HGET"] ++ [encode key] ++ [encode field] )
+hget key field =
+    sendRequest $ "HGET" :| (encode key : encode field : [])
 
 expireat
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> Integer -- ^ timestamp
     -> m (f Bool)
-expireat key timestamp = sendRequest (["EXPIREAT"] ++ [encode key] ++ [encode timestamp] )
+expireat key timestamp =
+    sendRequest $ "EXPIREAT" :| (encode key : encode timestamp : [])
 
 info
     :: (RedisCtx m f)
     => m (f ByteString)
-info  = sendRequest (["INFO"] )
+info  = sendRequest $ "INFO" :| []
 
 sdiff
     :: (RedisCtx m f)
-    => [ByteString] -- ^ key
+    => NonEmpty ByteString -- ^ key
     -> m (f [ByteString])
-sdiff key = sendRequest (["SDIFF"] ++ map encode key )
+sdiff key = sendRequest $ ("SDIFF" :| []) <> LNE.map encode key
 
 append
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> ByteString -- ^ value
     -> m (f Integer)
-append key value = sendRequest (["APPEND"] ++ [encode key] ++ [encode value] )
+append key value = sendRequest $ "APPEND" :| (encode key : encode value : [])
 
 lset
     :: (RedisCtx m f)
@@ -386,98 +412,108 @@ lset
     -> Integer -- ^ index
     -> ByteString -- ^ value
     -> m (f Status)
-lset key index value = sendRequest (["LSET"] ++ [encode key] ++ [encode index] ++ [encode value] )
+lset key index value =
+    sendRequest $ "LSET" :| (encode key : encode index : encode value : [])
 
 get
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f (Maybe ByteString))
-get key = sendRequest (["GET"] ++ [encode key] )
+get key = sendRequest $ "GET" :| [encode key]
 
 scriptFlush
     :: (RedisCtx m f)
     => m (f Status)
-scriptFlush  = sendRequest (["SCRIPT","FLUSH"] )
+scriptFlush = sendRequest $ "SCRIPT" :| ["FLUSH"]
 
 lpop
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f (Maybe ByteString))
-lpop key = sendRequest (["LPOP"] ++ [encode key] )
+lpop key = sendRequest $ "LPOP" :| [encode key]
 
 lastsave
     :: (RedisCtx m f)
     => m (f Integer)
-lastsave  = sendRequest (["LASTSAVE"] )
+lastsave  = sendRequest $ "LASTSAVE" :| []
 
 dbsize
     :: (RedisCtx m f)
     => m (f Integer)
-dbsize  = sendRequest (["DBSIZE"] )
+dbsize  = sendRequest $ "DBSIZE" :| []
 
 zadd
     :: (RedisCtx m f)
     => ByteString -- ^ key
-    -> [(Double,ByteString)] -- ^ scoreMember
+    -> NonEmpty (Double,ByteString) -- ^ scoreMember
     -> m (f Integer)
-zadd key scoreMember = sendRequest (["ZADD"] ++ [encode key] ++ concatMap (\(x,y) -> [encode x,encode y])scoreMember )
+zadd key scoreMember =
+    sendRequest $ "ZADD"
+                  :| (encode key : convertedScores)
+    where
+        convertedScores = sconcat (LNE.map (\(x,y) -> [encode x, encode y])
+                                           scoreMember)
 
 hmget
     :: (RedisCtx m f)
     => ByteString -- ^ key
-    -> [ByteString] -- ^ field
+    -> NonEmpty ByteString -- ^ field
     -> m (f [Maybe ByteString])
-hmget key field = sendRequest (["HMGET"] ++ [encode key] ++ map encode field )
+hmget key field = sendRequest $ ("HMGET" :| [encode key])
+                                <> LNE.map encode field
 
 expire
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> Integer -- ^ seconds
     -> m (f Bool)
-expire key seconds = sendRequest (["EXPIRE"] ++ [encode key] ++ [encode seconds] )
+expire key seconds =
+    sendRequest $ "EXPIRE" :| (encode key : encode seconds : [])
 
 mget
     :: (RedisCtx m f)
-    => [ByteString] -- ^ key
+    => NonEmpty ByteString -- ^ key
     -> m (f [Maybe ByteString])
-mget key = sendRequest (["MGET"] ++ map encode key )
+mget key = sendRequest $ ("MGET" :| []) <> LNE.map encode key
 
 hexists
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> ByteString -- ^ field
     -> m (f Bool)
-hexists key field = sendRequest (["HEXISTS"] ++ [encode key] ++ [encode field] )
+hexists key field = sendRequest $ "HEXISTS" :| (encode key : encode field : [])
 
 exists
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f Bool)
-exists key = sendRequest (["EXISTS"] ++ [encode key] )
+exists key = sendRequest $ "EXISTS" :| [encode key]
 
 sunion
     :: (RedisCtx m f)
-    => [ByteString] -- ^ key
+    => NonEmpty ByteString -- ^ key
     -> m (f [ByteString])
-sunion key = sendRequest (["SUNION"] ++ map encode key )
+sunion key = sendRequest $ ("SUNION" :| []) <> LNE.map encode key
 
 configSet
     :: (RedisCtx m f)
     => ByteString -- ^ parameter
     -> ByteString -- ^ value
     -> m (f Status)
-configSet parameter value = sendRequest (["CONFIG","SET"] ++ [encode parameter] ++ [encode value] )
+configSet parameter value =
+    sendRequest $ "CONFIG"
+                  :| ("SET" : encode parameter : encode value : [])
 
 smembers
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f [ByteString])
-smembers key = sendRequest (["SMEMBERS"] ++ [encode key] )
+smembers key = sendRequest $ "SMEMBERS" :| [encode key]
 
 ping
     :: (RedisCtx m f)
     => m (f Status)
-ping  = sendRequest (["PING"] )
+ping  = sendRequest ("PING" :| [])
 
 brpoplpush
     :: (RedisCtx m f)
@@ -485,20 +521,24 @@ brpoplpush
     -> ByteString -- ^ destination
     -> Integer -- ^ timeout
     -> m (f (Maybe ByteString))
-brpoplpush source destination timeout = sendRequest (["BRPOPLPUSH"] ++ [encode source] ++ [encode destination] ++ [encode timeout] )
+brpoplpush source destination timeout =
+    sendRequest $ "BRPOPLPUSH"
+                  :| (encode source : encode destination : encode timeout : [])
 
 rpop
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f (Maybe ByteString))
-rpop key = sendRequest (["RPOP"] ++ [encode key] )
+rpop key = sendRequest $ "RPOP" :| [encode key]
 
 incrbyfloat
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> Double -- ^ increment
     -> m (f Double)
-incrbyfloat key increment = sendRequest (["INCRBYFLOAT"] ++ [encode key] ++ [encode increment] )
+incrbyfloat key increment =
+    sendRequest $ "INCRBYFLOAT"
+                  :| (encode key : encode increment : [])
 
 setrange
     :: (RedisCtx m f)
@@ -506,7 +546,8 @@ setrange
     -> Integer -- ^ offset
     -> ByteString -- ^ value
     -> m (f Integer)
-setrange key offset value = sendRequest (["SETRANGE"] ++ [encode key] ++ [encode offset] ++ [encode value] )
+setrange key offset value =
+    sendRequest $ "SETRANGE" :| (encode key : encode offset : encode value : [])
 
 hincrbyfloat
     :: (RedisCtx m f)
@@ -514,47 +555,55 @@ hincrbyfloat
     -> ByteString -- ^ field
     -> Double -- ^ increment
     -> m (f Double)
-hincrbyfloat key field increment = sendRequest (["HINCRBYFLOAT"] ++ [encode key] ++ [encode field] ++ [encode increment] )
+hincrbyfloat key field increment =
+    sendRequest $ "HINCRBYFLOAT"
+                  :| (encode key : encode field : encode increment : [])
 
 zrevrank
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> ByteString -- ^ member
     -> m (f (Maybe Integer))
-zrevrank key member = sendRequest (["ZREVRANK"] ++ [encode key] ++ [encode member] )
+zrevrank key member =
+    sendRequest $ "ZREVRANK" :| (encode key : encode member : [])
 
 lindex
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> Integer -- ^ index
     -> m (f (Maybe ByteString))
-lindex key index = sendRequest (["LINDEX"] ++ [encode key] ++ [encode index] )
+lindex key index =
+    sendRequest $ "LINDEX" :| (encode key : encode index : [])
 
 sadd
     :: (RedisCtx m f)
     => ByteString -- ^ key
-    -> [ByteString] -- ^ member
+    -> NonEmpty ByteString -- ^ member
     -> m (f Integer)
-sadd key member = sendRequest (["SADD"] ++ [encode key] ++ map encode member )
+sadd key member =
+    sendRequest $ ("SADD" :| [encode key])
+                  <> LNE.map encode member
 
 srandmember
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f (Maybe ByteString))
-srandmember key = sendRequest (["SRANDMEMBER"] ++ [encode key] )
+srandmember key = sendRequest $ "SRANDMEMBER" :| [encode key]
 
 zscore
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> ByteString -- ^ member
     -> m (f (Maybe Double))
-zscore key member = sendRequest (["ZSCORE"] ++ [encode key] ++ [encode member] )
+zscore key member =
+    sendRequest $ "ZSCORE"
+                  :| (encode key : encode member : [])
 
 persist
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f Bool)
-persist key = sendRequest (["PERSIST"] ++ [encode key] )
+persist key = sendRequest $ "PERSIST" :| [encode key]
 
 zincrby
     :: (RedisCtx m f)
@@ -562,33 +611,43 @@ zincrby
     -> Integer -- ^ increment
     -> ByteString -- ^ member
     -> m (f Double)
-zincrby key increment member = sendRequest (["ZINCRBY"] ++ [encode key] ++ [encode increment] ++ [encode member] )
+zincrby key increment member =
+    sendRequest $ "ZINCRBY"
+                  :| (encode key : encode increment : encode member : [])
 
 rpoplpush
     :: (RedisCtx m f)
     => ByteString -- ^ source
     -> ByteString -- ^ destination
     -> m (f (Maybe ByteString))
-rpoplpush source destination = sendRequest (["RPOPLPUSH"] ++ [encode source] ++ [encode destination] )
+rpoplpush source destination =
+    sendRequest $ "RPOPLPUSH" :| (encode source : encode destination : [])
 
 hgetall
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f [(ByteString,ByteString)])
-hgetall key = sendRequest (["HGETALL"] ++ [encode key] )
+hgetall key = sendRequest $ "HGETALL" :| [encode key]
 
 mset
     :: (RedisCtx m f)
-    => [(ByteString,ByteString)] -- ^ keyValue
+    => NonEmpty (ByteString,ByteString) -- ^ keyValue
     -> m (f Status)
-mset keyValue = sendRequest (["MSET"] ++ concatMap (\(x,y) -> [encode x,encode y])keyValue )
+mset keyValue =
+    sendRequest $ "MSET" :| sconcat (LNE.map (\(x,y) -> [encode x,encode y])
+                                             keyValue)
 
 hmset
     :: (RedisCtx m f)
     => ByteString -- ^ key
-    -> [(ByteString,ByteString)] -- ^ fieldValue
+    -> NonEmpty (ByteString,ByteString) -- ^ fieldValue
     -> m (f Status)
-hmset key fieldValue = sendRequest (["HMSET"] ++ [encode key] ++ concatMap (\(x,y) -> [encode x,encode y])fieldValue )
+hmset key fieldValue =
+    sendRequest $ "HMSET"
+                  :| (encode key : convertedFieldValues)
+    where
+        convertedFieldValues = sconcat (LNE.map (\(x,y) -> [encode x,encode y])
+                                                fieldValue)
 
 psetex
     :: (RedisCtx m f)
@@ -596,14 +655,19 @@ psetex
     -> Integer -- ^ milliseconds
     -> ByteString -- ^ value
     -> m (f Status)
-psetex key milliseconds value = sendRequest (["PSETEX"] ++ [encode key] ++ [encode milliseconds] ++ [encode value] )
+psetex key milliseconds value =
+    sendRequest $ "PSETEX"
+                  :| (encode key : encode milliseconds : encode value : [])
 
 brpop
     :: (RedisCtx m f)
-    => [ByteString] -- ^ key
+    => NonEmpty ByteString -- ^ key
     -> Integer -- ^ timeout
     -> m (f (Maybe (ByteString,ByteString)))
-brpop key timeout = sendRequest (["BRPOP"] ++ map encode key ++ [encode timeout] )
+brpop key timeout =
+    sendRequest $ ("BRPOP" :| [])
+                  <> LNE.map encode key
+                  <> (encode timeout :| [])
 
 hsetnx
     :: (RedisCtx m f)
@@ -611,114 +675,120 @@ hsetnx
     -> ByteString -- ^ field
     -> ByteString -- ^ value
     -> m (f Bool)
-hsetnx key field value = sendRequest (["HSETNX"] ++ [encode key] ++ [encode field] ++ [encode value] )
+hsetnx key field value =
+    sendRequest $ "HSETNX" :| (encode key : encode field : encode value : [])
 
 configGet
     :: (RedisCtx m f)
     => ByteString -- ^ parameter
     -> m (f [(ByteString,ByteString)])
-configGet parameter = sendRequest (["CONFIG","GET"] ++ [encode parameter] )
+configGet parameter =
+    sendRequest $ "CONFIG" :| ("GET" : encode parameter : [])
 
 zrank
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> ByteString -- ^ member
     -> m (f (Maybe Integer))
-zrank key member = sendRequest (["ZRANK"] ++ [encode key] ++ [encode member] )
+zrank key member = sendRequest $ "ZRANK" :| (encode key : encode member : [])
 
 hkeys
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f [ByteString])
-hkeys key = sendRequest (["HKEYS"] ++ [encode key] )
+hkeys key = sendRequest $ "HKEYS" :| [encode key]
 
 ttl
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f Integer)
-ttl key = sendRequest (["TTL"] ++ [encode key] )
+ttl key = sendRequest $ "TTL" :| [encode key]
 
 getset
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> ByteString -- ^ value
     -> m (f (Maybe ByteString))
-getset key value = sendRequest (["GETSET"] ++ [encode key] ++ [encode value] )
+getset key value = sendRequest $ "GETSET" :| (encode key : encode value : [])
 
 slaveof
     :: (RedisCtx m f)
     => ByteString -- ^ host
     -> ByteString -- ^ port
     -> m (f Status)
-slaveof host port = sendRequest (["SLAVEOF"] ++ [encode host] ++ [encode port] )
+slaveof host port = sendRequest $ "SLAVEOF" :| (encode host : encode port : [])
 
 setnx
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> ByteString -- ^ value
     -> m (f Bool)
-setnx key value = sendRequest (["SETNX"] ++ [encode key] ++ [encode value] )
+setnx key value = sendRequest $ "SETNX" :| (encode key : encode value : [])
 
 dump
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f ByteString)
-dump key = sendRequest (["DUMP"] ++ [encode key] )
+dump key = sendRequest $ "DUMP" :| [encode key]
 
 keys
     :: (RedisCtx m f)
     => ByteString -- ^ pattern
     -> m (f [ByteString])
-keys pattern = sendRequest (["KEYS"] ++ [encode pattern] )
+keys pattern = sendRequest $ "KEYS" :| [encode pattern]
 
 echo
     :: (RedisCtx m f)
     => ByteString -- ^ message
     -> m (f ByteString)
-echo message = sendRequest (["ECHO"] ++ [encode message] )
+echo message = sendRequest $ "ECHO" :| [encode message]
 
 getbit
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> Integer -- ^ offset
     -> m (f Integer)
-getbit key offset = sendRequest (["GETBIT"] ++ [encode key] ++ [encode offset] )
+getbit key offset = sendRequest $ "GETBIT" :| (encode key : encode offset : [])
 
 quit
     :: (RedisCtx m f)
     => m (f Status)
-quit  = sendRequest (["QUIT"] )
+quit  = sendRequest $ "QUIT" :| []
 
 srem
     :: (RedisCtx m f)
     => ByteString -- ^ key
-    -> [ByteString] -- ^ member
+    -> NonEmpty ByteString -- ^ member
     -> m (f Integer)
-srem key member = sendRequest (["SREM"] ++ [encode key] ++ map encode member )
+srem key member =
+    sendRequest $ ("SREM" :| [encode key]) <> LNE.map encode member
 
 move
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> Integer -- ^ db
     -> m (f Bool)
-move key db = sendRequest (["MOVE"] ++ [encode key] ++ [encode db] )
+move key db = sendRequest $ "MOVE" :| (encode key : encode db : [])
 
 scriptLoad
     :: (RedisCtx m f)
     => ByteString -- ^ script
     -> m (f ByteString)
-scriptLoad script = sendRequest (["SCRIPT","LOAD"] ++ [encode script] )
+scriptLoad script = sendRequest $ "SCRIPT" :| ("LOAD" : encode script : [])
 
 msetnx
     :: (RedisCtx m f)
-    => [(ByteString,ByteString)] -- ^ keyValue
+    => NonEmpty (ByteString,ByteString) -- ^ keyValue
     -> m (f Bool)
-msetnx keyValue = sendRequest (["MSETNX"] ++ concatMap (\(x,y) -> [encode x,encode y])keyValue )
+msetnx keyValue =
+    sendRequest $ "MSETNX"
+                  :| sconcat (LNE.map (\(x,y) -> [encode x,encode y])
+                                      keyValue)
 
 save
     :: (RedisCtx m f)
     => m (f Status)
-save  = sendRequest (["SAVE"] )
+save = sendRequest $ "SAVE" :| []
 
 ltrim
     :: (RedisCtx m f)
@@ -726,7 +796,8 @@ ltrim
     -> Integer -- ^ start
     -> Integer -- ^ stop
     -> m (f Status)
-ltrim key start stop = sendRequest (["LTRIM"] ++ [encode key] ++ [encode start] ++ [encode stop] )
+ltrim key start stop =
+    sendRequest $ "LTRIM" :| (encode key : encode start : encode stop : [])
 
 lrem
     :: (RedisCtx m f)
@@ -734,47 +805,53 @@ lrem
     -> Integer -- ^ count
     -> ByteString -- ^ value
     -> m (f Integer)
-lrem key count value = sendRequest (["LREM"] ++ [encode key] ++ [encode count] ++ [encode value] )
+lrem key count value =
+    sendRequest $ "LREM" :| (encode key : encode count : encode value : [])
 
 pexpireat
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> Integer -- ^ millisecondsTimestamp
     -> m (f Bool)
-pexpireat key millisecondsTimestamp = sendRequest (["PEXPIREAT"] ++ [encode key] ++ [encode millisecondsTimestamp] )
+pexpireat key millisecondsTimestamp =
+    sendRequest $ "PEXPIREAT"
+                  :| (encode key : encode millisecondsTimestamp : [])
 
 zcard
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f Integer)
-zcard key = sendRequest (["ZCARD"] ++ [encode key] )
+zcard key = sendRequest $ "ZCARD" :| [encode key]
 
 renamenx
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> ByteString -- ^ newkey
     -> m (f Bool)
-renamenx key newkey = sendRequest (["RENAMENX"] ++ [encode key] ++ [encode newkey] )
+renamenx key newkey =
+    sendRequest $ "RENAMENX" :| (encode key : encode newkey : [])
 
 llen
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f Integer)
-llen key = sendRequest (["LLEN"] ++ [encode key] )
+llen key = sendRequest $ "LLEN" :| [encode key]
 
 pexpire
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> Integer -- ^ milliseconds
     -> m (f Bool)
-pexpire key milliseconds = sendRequest (["PEXPIRE"] ++ [encode key] ++ [encode milliseconds] )
+pexpire key milliseconds =
+    sendRequest $ "PEXPIRE" :| (encode key : encode milliseconds : [])
 
 decrby
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> Integer -- ^ decrement
     -> m (f Integer)
-decrby key decrement = sendRequest (["DECRBY"] ++ [encode key] ++ [encode decrement] )
+decrby key decrement =
+    sendRequest $ "DECRBY" :| (encode key : encode decrement : [])
 
 lrange
     :: (RedisCtx m f)
@@ -782,21 +859,25 @@ lrange
     -> Integer -- ^ start
     -> Integer -- ^ stop
     -> m (f [ByteString])
-lrange key start stop = sendRequest (["LRANGE"] ++ [encode key] ++ [encode start] ++ [encode stop] )
+lrange key start stop =
+    sendRequest $ "LRANGE" :| (encode key : encode start : encode stop : [])
 
 sinterstore
     :: (RedisCtx m f)
     => ByteString -- ^ destination
-    -> [ByteString] -- ^ key
+    -> NonEmpty ByteString -- ^ key
     -> m (f Integer)
-sinterstore destination key = sendRequest (["SINTERSTORE"] ++ [encode destination] ++ map encode key )
+sinterstore destination key =
+    sendRequest $ ("SINTERSTORE" :| [encode destination])
+                  <> LNE.map encode key
 
 rename
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> ByteString -- ^ newkey
     -> m (f Status)
-rename key newkey = sendRequest (["RENAME"] ++ [encode key] ++ [encode newkey] )
+rename key newkey =
+    sendRequest $ "RENAME" :| (encode key : encode newkey : [])
 
 restore
     :: (RedisCtx m f)
@@ -804,43 +885,47 @@ restore
     -> Integer -- ^ timeToLive
     -> ByteString -- ^ serializedValue
     -> m (f Status)
-restore key timeToLive serializedValue = sendRequest (["RESTORE"] ++ [encode key] ++ [encode timeToLive] ++ [encode serializedValue] )
+restore key timeToLive serializedValue =
+    sendRequest $ "RESTORE" :| (encode key : encode timeToLive
+                                : encode serializedValue : [])
 
 hvals
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f [ByteString])
-hvals key = sendRequest (["HVALS"] ++ [encode key] )
+hvals key = sendRequest $ "HVALS" :| [encode key]
 
 zrem
     :: (RedisCtx m f)
     => ByteString -- ^ key
-    -> [ByteString] -- ^ member
+    -> NonEmpty ByteString -- ^ member
     -> m (f Integer)
-zrem key member = sendRequest (["ZREM"] ++ [encode key] ++ map encode member )
+zrem key member =
+    sendRequest $ ("ZREM" :| [encode key])
+                  <> LNE.map encode member
 
 decr
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f Integer)
-decr key = sendRequest (["DECR"] ++ [encode key] )
+decr key = sendRequest $ "DECR" :| [encode key]
 
 configResetstat
     :: (RedisCtx m f)
     => m (f Status)
-configResetstat  = sendRequest (["CONFIG","RESETSTAT"] )
+configResetstat  = sendRequest $ "CONFIG" :| ["RESETSTAT"]
 
 flushall
     :: (RedisCtx m f)
     => m (f Status)
-flushall  = sendRequest (["FLUSHALL"] )
+flushall  = sendRequest $ "FLUSHALL" :| []
 
 hdel
     :: (RedisCtx m f)
     => ByteString -- ^ key
-    -> [ByteString] -- ^ field
+    -> NonEmpty ByteString -- ^ field
     -> m (f Integer)
-hdel key field = sendRequest (["HDEL"] ++ [encode key] ++ map encode field )
+hdel key field = sendRequest $ ("HDEL" :| [encode key]) <> LNE.map encode field
 
 setbit
     :: (RedisCtx m f)
@@ -848,25 +933,27 @@ setbit
     -> Integer -- ^ offset
     -> ByteString -- ^ value
     -> m (f Integer)
-setbit key offset value = sendRequest (["SETBIT"] ++ [encode key] ++ [encode offset] ++ [encode value] )
+setbit key offset value =
+    sendRequest $ "SETBIT" :| (encode key : encode offset : encode value : [])
 
 del
     :: (RedisCtx m f)
-    => [ByteString] -- ^ key
+    => NonEmpty ByteString -- ^ key
     -> m (f Integer)
-del key = sendRequest (["DEL"] ++ map encode key )
+del key = sendRequest $ ("DEL" :| []) <> LNE.map encode key
 
 scriptKill
     :: (RedisCtx m f)
     => m (f Status)
-scriptKill  = sendRequest (["SCRIPT","KILL"] )
+scriptKill  = sendRequest $ "SCRIPT" :| ["KILL"]
 
 incrby
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> Integer -- ^ increment
     -> m (f Integer)
-incrby key increment = sendRequest (["INCRBY"] ++ [encode key] ++ [encode increment] )
+incrby key increment =
+    sendRequest $ "INCRBY" :| (encode key : encode increment : [])
 
 hincrby
     :: (RedisCtx m f)
@@ -874,12 +961,14 @@ hincrby
     -> ByteString -- ^ field
     -> Integer -- ^ increment
     -> m (f Integer)
-hincrby key field increment = sendRequest (["HINCRBY"] ++ [encode key] ++ [encode field] ++ [encode increment] )
+hincrby key field increment =
+    sendRequest $ "HINCRBY"
+                  :| (encode key : encode field : encode increment : [])
 
 time
     :: (RedisCtx m f)
     => m (f (Integer,Integer))
-time  = sendRequest (["TIME"] )
+time  = sendRequest $ "TIME" :| []
 
 hset
     :: (RedisCtx m f)
@@ -887,25 +976,27 @@ hset
     -> ByteString -- ^ field
     -> ByteString -- ^ value
     -> m (f Bool)
-hset key field value = sendRequest (["HSET"] ++ [encode key] ++ [encode field] ++ [encode value] )
+hset key field value =
+    sendRequest $ "HSET" :| (encode key : encode field : encode value : [])
 
 strlen
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f Integer)
-strlen key = sendRequest (["STRLEN"] ++ [encode key] )
+strlen key = sendRequest $ "STRLEN" :| [encode key]
 
 flushdb
     :: (RedisCtx m f)
     => m (f Status)
-flushdb  = sendRequest (["FLUSHDB"] )
+flushdb  = sendRequest $ "FLUSHDB" :| []
 
 lpushx
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> ByteString -- ^ value
     -> m (f Integer)
-lpushx key value = sendRequest (["LPUSHX"] ++ [encode key] ++ [encode value] )
+lpushx key value =
+    sendRequest $ "LPUSHX" :| (encode key : encode value : [])
 
 smove
     :: (RedisCtx m f)
@@ -913,7 +1004,8 @@ smove
     -> ByteString -- ^ destination
     -> ByteString -- ^ member
     -> m (f Bool)
-smove source destination member = sendRequest (["SMOVE"] ++ [encode source] ++ [encode destination] ++ [encode member] )
+smove source destination member =
+    sendRequest $ "SMOVE" :| (encode source : encode destination : encode member : [])
 
 zremrangebyrank
     :: (RedisCtx m f)
@@ -921,21 +1013,21 @@ zremrangebyrank
     -> Integer -- ^ start
     -> Integer -- ^ stop
     -> m (f Integer)
-zremrangebyrank key start stop = sendRequest (["ZREMRANGEBYRANK"] ++ [encode key] ++ [encode start] ++ [encode stop] )
+zremrangebyrank key start stop =
+    sendRequest $ "ZREMRANGEBYRANK"
+                  :| (encode key : encode start : encode stop : [])
 
 set
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> ByteString -- ^ value
     -> m (f Status)
-set key value = sendRequest (["SET"] ++ [encode key] ++ [encode value] )
+set key value = sendRequest $ "SET" :| (encode key : encode value : [])
 
 lpush
     :: (RedisCtx m f)
     => ByteString -- ^ key
-    -> [ByteString] -- ^ value
+    -> NonEmpty ByteString -- ^ value
     -> m (f Integer)
-lpush key value = sendRequest (["LPUSH"] ++ [encode key] ++ map encode value )
-
-
-
+lpush key value = sendRequest $ ("LPUSH" :| [encode key])
+                                <> LNE.map encode value

--- a/src/Database/Redis/ManualCommands.hs
+++ b/src/Database/Redis/ManualCommands.hs
@@ -4,28 +4,30 @@ module Database.Redis.ManualCommands where
 
 import Prelude hiding (min,max)
 import Data.ByteString (ByteString)
+import Data.List.NonEmpty (NonEmpty(..))
 import Database.Redis.Core
 import Database.Redis.Protocol
 import Database.Redis.Types
+import qualified Data.List.NonEmpty as LNE
 
 
 objectRefcount
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f Integer)
-objectRefcount key = sendRequest ["OBJECT", "refcount", encode key]
+objectRefcount key = sendRequest ("OBJECT" :| ["refcount", encode key])
 
 objectIdletime
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f Integer)
-objectIdletime key = sendRequest ["OBJECT", "idletime", encode key]
+objectIdletime key = sendRequest ("OBJECT" :| ["idletime", encode key])
 
 objectEncoding
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f ByteString)
-objectEncoding key = sendRequest ["OBJECT", "encoding", encode key]
+objectEncoding key = sendRequest ("OBJECT" :| ["encoding", encode key])
 
 linsertBefore
     :: (RedisCtx m f)
@@ -34,7 +36,8 @@ linsertBefore
     -> ByteString -- ^ value
     -> m (f Integer)
 linsertBefore key pivot value =
-    sendRequest ["LINSERT", encode key, "BEFORE", encode pivot, encode value]
+    sendRequest ("LINSERT" :| [encode key, "BEFORE", encode pivot,
+                               encode value])
 
 linsertAfter
     :: (RedisCtx m f)
@@ -43,13 +46,14 @@ linsertAfter
     -> ByteString -- ^ value
     -> m (f Integer)
 linsertAfter key pivot value =
-        sendRequest ["LINSERT", encode key, "AFTER", encode pivot, encode value]
+    sendRequest ("LINSERT" :| [encode key, "AFTER", encode pivot,
+                               encode value])
 
 getType
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f RedisType)
-getType key = sendRequest ["TYPE", encode key]
+getType key = sendRequest ("TYPE" :| [encode key])
 
 -- |A single entry from the slowlog.
 data Slowlog = Slowlog
@@ -76,13 +80,13 @@ slowlogGet
     :: (RedisCtx m f)
     => Integer -- ^ cnt
     -> m (f [Slowlog])
-slowlogGet n = sendRequest ["SLOWLOG", "GET", encode n]
+slowlogGet n = sendRequest ("SLOWLOG" :| ["GET", encode n])
 
 slowlogLen :: (RedisCtx m f) => m (f Integer)
-slowlogLen = sendRequest ["SLOWLOG", "LEN"]
+slowlogLen = sendRequest ("SLOWLOG" :| ["LEN"])
 
 slowlogReset :: (RedisCtx m f) => m (f Status)
-slowlogReset = sendRequest ["SLOWLOG", "RESET"]
+slowlogReset = sendRequest ("SLOWLOG" :| ["RESET"])
 
 zrange
     :: (RedisCtx m f)
@@ -91,7 +95,7 @@ zrange
     -> Integer -- ^ stop
     -> m (f [ByteString])
 zrange key start stop =
-    sendRequest ["ZRANGE", encode key, encode start, encode stop]
+    sendRequest ("ZRANGE" :| [encode key, encode start, encode stop])
 
 zrangeWithscores
     :: (RedisCtx m f)
@@ -100,7 +104,8 @@ zrangeWithscores
     -> Integer -- ^ stop
     -> m (f [(ByteString, Double)])
 zrangeWithscores key start stop =
-    sendRequest ["ZRANGE", encode key, encode start, encode stop, "WITHSCORES"]
+    sendRequest ("ZRANGE" :| [encode key, encode start, encode stop,
+                              "WITHSCORES"])
 
 zrevrange
     :: (RedisCtx m f)
@@ -109,7 +114,7 @@ zrevrange
     -> Integer -- ^ stop
     -> m (f [ByteString])
 zrevrange key start stop =
-    sendRequest ["ZREVRANGE", encode key, encode start, encode stop]
+    sendRequest ("ZREVRANGE" :| [encode key, encode start, encode stop])
 
 zrevrangeWithscores
     :: (RedisCtx m f)
@@ -118,8 +123,8 @@ zrevrangeWithscores
     -> Integer -- ^ stop
     -> m (f [(ByteString, Double)])
 zrevrangeWithscores key start stop =
-    sendRequest ["ZREVRANGE", encode key, encode start, encode stop
-                ,"WITHSCORES"]
+    sendRequest ("ZREVRANGE" :| [encode key, encode start, encode stop
+                                ,"WITHSCORES"])
 
 zrangebyscore
     :: (RedisCtx m f)
@@ -128,7 +133,7 @@ zrangebyscore
     -> Double -- ^ max
     -> m (f [ByteString])
 zrangebyscore key min max =
-    sendRequest ["ZRANGEBYSCORE", encode key, encode min, encode max]
+    sendRequest ("ZRANGEBYSCORE" :| [encode key, encode min, encode max])
 
 zrangebyscoreWithscores
     :: (RedisCtx m f)
@@ -137,8 +142,8 @@ zrangebyscoreWithscores
     -> Double -- ^ max
     -> m (f [(ByteString, Double)])
 zrangebyscoreWithscores key min max =
-    sendRequest ["ZRANGEBYSCORE", encode key, encode min, encode max
-                ,"WITHSCORES"]
+    sendRequest ("ZRANGEBYSCORE" :| [encode key, encode min, encode max
+                                    ,"WITHSCORES"])
 
 zrangebyscoreLimit
     :: (RedisCtx m f)
@@ -149,8 +154,8 @@ zrangebyscoreLimit
     -> Integer -- ^ count
     -> m (f [ByteString])
 zrangebyscoreLimit key min max offset count =
-    sendRequest ["ZRANGEBYSCORE", encode key, encode min, encode max
-                ,"LIMIT", encode offset, encode count]
+    sendRequest ("ZRANGEBYSCORE" :| [encode key, encode min, encode max
+                                    ,"LIMIT", encode offset, encode count])
 
 zrangebyscoreWithscoresLimit
     :: (RedisCtx m f)
@@ -161,8 +166,9 @@ zrangebyscoreWithscoresLimit
     -> Integer -- ^ count
     -> m (f [(ByteString, Double)])
 zrangebyscoreWithscoresLimit key min max offset count =
-    sendRequest ["ZRANGEBYSCORE", encode key, encode min, encode max
-                ,"WITHSCORES","LIMIT", encode offset, encode count]
+    sendRequest ("ZRANGEBYSCORE" :| [encode key, encode min, encode max
+                                    ,"WITHSCORES","LIMIT", encode offset
+                                    ,encode count])
 
 zrevrangebyscore
     :: (RedisCtx m f)
@@ -171,7 +177,7 @@ zrevrangebyscore
     -> Double -- ^ min
     -> m (f [ByteString])
 zrevrangebyscore key min max =
-    sendRequest ["ZREVRANGEBYSCORE", encode key, encode min, encode max]
+    sendRequest ("ZREVRANGEBYSCORE" :| [encode key, encode min, encode max])
 
 zrevrangebyscoreWithscores
     :: (RedisCtx m f)
@@ -180,8 +186,8 @@ zrevrangebyscoreWithscores
     -> Double -- ^ min
     -> m (f [(ByteString, Double)])
 zrevrangebyscoreWithscores key min max =
-    sendRequest ["ZREVRANGEBYSCORE", encode key, encode min, encode max
-                ,"WITHSCORES"]
+    sendRequest ("ZREVRANGEBYSCORE" :| [encode key, encode min, encode max
+                                       ,"WITHSCORES"])
 
 zrevrangebyscoreLimit
     :: (RedisCtx m f)
@@ -192,8 +198,8 @@ zrevrangebyscoreLimit
     -> Integer -- ^ count
     -> m (f [ByteString])
 zrevrangebyscoreLimit key min max offset count =
-    sendRequest ["ZREVRANGEBYSCORE", encode key, encode min, encode max
-                ,"LIMIT", encode offset, encode count]
+    sendRequest ("ZREVRANGEBYSCORE" :| [encode key, encode min, encode max
+                                       ,"LIMIT", encode offset, encode count])
 
 zrevrangebyscoreWithscoresLimit
     :: (RedisCtx m f)
@@ -204,8 +210,9 @@ zrevrangebyscoreWithscoresLimit
     -> Integer -- ^ count
     -> m (f [(ByteString, Double)])
 zrevrangebyscoreWithscoresLimit key min max offset count =
-    sendRequest ["ZREVRANGEBYSCORE", encode key, encode min, encode max
-                ,"WITHSCORES","LIMIT", encode offset, encode count]
+    sendRequest ("ZREVRANGEBYSCORE"
+                 :| [encode key, encode min, encode max
+                    ,"WITHSCORES","LIMIT", encode offset, encode count])
 
 -- |Options for the 'sort' command.
 data SortOpts = SortOpts
@@ -260,7 +267,7 @@ sortInternal
     -> Maybe ByteString -- ^ destination
     -> SortOpts
     -> m (f a)
-sortInternal key destination SortOpts{..} = sendRequest $
+sortInternal key destination SortOpts{..} = sendRequest $ LNE.fromList $
     concat [["SORT", encode key], by, limit, get, order, alpha, store]
   where
     by    = maybe [] (\pattern -> ["BY", pattern]) sortBy
@@ -319,7 +326,7 @@ zstoreInternal
     -> [Double] -- ^ weights
     -> Aggregate    
     -> m (f Integer)
-zstoreInternal cmd dest keys weights aggregate = sendRequest $
+zstoreInternal cmd dest keys weights aggregate = sendRequest $ LNE.fromList $
     concat [ [cmd, dest, encode . toInteger $ length keys], keys
            , if null weights then [] else "WEIGHTS" : map encode weights
            , ["AGGREGATE", aggregate']
@@ -337,7 +344,7 @@ eval
     -> [ByteString] -- ^ args
     -> m (f a)
 eval script keys args =
-    sendRequest $ ["EVAL", script, encode numkeys] ++ keys ++ args
+    sendRequest $ "EVAL" :| (script : encode numkeys : (keys ++ args))
   where
     numkeys = toInteger (length keys)
 
@@ -348,7 +355,7 @@ evalsha
     -> [ByteString] -- ^ args
     -> m (f a)
 evalsha script keys args =
-    sendRequest $ ["EVALSHA", script, encode numkeys] ++ keys ++ args
+    sendRequest $ "EVALSHA" :| (script : encode numkeys : (keys ++ args))
   where
     numkeys = toInteger (length keys)
 
@@ -356,7 +363,7 @@ bitcount
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> m (f Integer)
-bitcount key = sendRequest ["BITCOUNT", key]
+bitcount key = sendRequest ("BITCOUNT" :| [key])
 
 bitcountRange
     :: (RedisCtx m f)
@@ -365,7 +372,7 @@ bitcountRange
     -> Integer -- ^ end
     -> m (f Integer)
 bitcountRange key start end =
-    sendRequest ["BITCOUNT", key, encode start, encode end]
+    sendRequest ("BITCOUNT" :| [key, encode start, encode end])
 
 bitopAnd
     :: (RedisCtx m f)
@@ -400,4 +407,4 @@ bitop
     => ByteString -- ^ operation
     -> [ByteString] -- ^ keys
     -> m (f Integer)
-bitop op ks = sendRequest $ "BITOP" : op : ks
+bitop op ks = sendRequest ("BITOP" :| (op : ks))

--- a/src/Database/Redis/Protocol.hs
+++ b/src/Database/Redis/Protocol.hs
@@ -7,6 +7,8 @@ import Control.Applicative
 import Data.Attoparsec (takeTill)
 import Data.Attoparsec.Char8 hiding (takeTill)
 import Data.ByteString.Char8 (ByteString)
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as LNE
 import qualified Data.ByteString.Char8 as B
 
 -- |Low-level representation of replies from the Redis server.
@@ -20,11 +22,11 @@ data Reply = SingleLine ByteString
 ------------------------------------------------------------------------------
 -- Request
 --
-renderRequest :: [ByteString] -> ByteString
-renderRequest req = B.concat (argCnt:args)
+renderRequest :: NonEmpty ByteString -> ByteString
+renderRequest req = B.concat $ argCnt : args
   where
-    argCnt = B.concat ["*", showBS (length req), crlf]
-    args   = map renderArg req
+    argCnt = B.concat ["*", showBS (LNE.length req), crlf]
+    args   = map renderArg (LNE.toList req)
 
 renderArg :: ByteString -> ByteString
 renderArg arg = B.concat ["$",  argLen arg, crlf, arg, crlf]

--- a/src/Database/Redis/PubSub.hs
+++ b/src/Database/Redis/PubSub.hs
@@ -13,6 +13,7 @@ import Control.Applicative
 import Control.Monad
 import Control.Monad.State
 import Data.ByteString.Char8 (ByteString)
+import Data.List.NonEmpty (NonEmpty(..))
 import Data.Monoid
 import qualified Database.Redis.Core as Core
 import Database.Redis.Protocol (Reply(..))
@@ -78,7 +79,7 @@ class Command a where
 sendCmd :: (Command (Cmd a b)) => Cmd a b -> StateT PubSubState Core.Redis ()
 sendCmd DoNothing = return ()
 sendCmd cmd       = do
-    lift $ Core.send (redisCmd cmd : changes cmd)
+    lift $ Core.send (redisCmd cmd :| changes cmd)
     modifyPending (updatePending cmd)
 
 plusChangeCnt :: Cmd a b -> Int -> Int
@@ -120,7 +121,7 @@ publish
     -> ByteString -- ^ message
     -> m (f Integer)
 publish channel message =
-    Core.sendRequest ["PUBLISH", channel, message]
+    Core.sendRequest ("PUBLISH" :| [channel, message])
 
 -- |Listen for messages published to the given channels
 --  (<http://redis.io/commands/subscribe>).

--- a/src/Database/Redis/Transactions.hs
+++ b/src/Database/Redis/Transactions.hs
@@ -10,6 +10,8 @@ import Control.Applicative
 import Control.Monad.State.Strict
 import Data.ByteString (ByteString)
 import Data.Vector (Vector, fromList, (!))
+import Data.List.NonEmpty (NonEmpty(..))
+import Data.Semigroup ((<>))
 
 import Database.Redis.Core
 import Database.Redis.Protocol
@@ -77,13 +79,13 @@ data TxResult a
 -- |Watch the given keys to determine execution of the MULTI\/EXEC block
 --  (<http://redis.io/commands/watch>).
 watch
-    :: [ByteString] -- ^ key
+    :: NonEmpty ByteString -- ^ key
     -> Redis (Either Reply Status)
-watch key = sendRequest ("WATCH" : key)
+watch key = sendRequest (("WATCH" :| []) <> key)
 
 -- |Forget about all watched keys (<http://redis.io/commands/unwatch>).
 unwatch :: Redis (Either Reply Status)
-unwatch  = sendRequest ["UNWATCH"]
+unwatch  = sendRequest ("UNWATCH" :| [])
 
 
 -- |Run commands inside a transaction. For documentation on the semantics of
@@ -123,7 +125,7 @@ multiExec rtx = do
         _ -> error $ "hedis: EXEC returned " ++ show r
 
 multi :: Redis (Either Reply Status)
-multi = sendRequest ["MULTI"]
+multi = sendRequest ("MULTI" :| [])
 
 exec :: Redis Reply
-exec = either id id <$> sendRequest ["EXEC"]
+exec = either id id <$> sendRequest ("EXEC" :| [])


### PR DESCRIPTION
Hi!

I had quite a long debug-session 2 days ago before I figured out what exactly happened. Consider this piece of code:

```
{-# LANGUAGE OverloadedStrings #-}

import Database.Redis

main :: IO ()
main = do
    redis <- connect defaultConnectInfo
    putStrLn "Will try to add empty list into set not inside transaction"
    res <- runRedis redis $ do
         sadd "test-set" []
    putStrLn "Done."
    putStrLn $ "res: " ++ show res
    putStrLn "Will try to add empty list into set inside transaction"
    runRedis redis $ multiExec $ do
         sadd "test-set" []
    putStrLn "Success"
```

Output it produces is this:

```
➜  hedis-sadd-empty  ./dist/build/hedis-sadd-empty/hedis-sadd-empty
Will try to add empty list into set not inside transaction
Done.
res: Left (Error "ERR wrong number of arguments for 'sadd' command")
Will try to add empty list into set inside transaction
hedis-sadd-empty: hedis: EXEC returned Error "EXECABORT Transaction discarded because of previous errors."
```

So, as you can see, first case is OK more or less since it just returns Left which you can skip, but if you do `sadd` with empty list inside transaction, that is kind of a disaster (runtime exception with no good hint). But of course even first case is not good also.

With this PR I propose to use `Data.List.NonEmpty` from `semigroups` package to explicitly state that argument we want should be non-empty list. I think this would improve hedis's safety quite a bit.

I know this change is quite massive API change, but I having this kind of guarantee that your code will not misbehave is much more important.

Thanks!
