### PR TITLE
Use BlockBuffering on socket handle

### DIFF
--- a/src/Database/Redis/ProtocolPipelining.hs
+++ b/src/Database/Redis/ProtocolPipelining.hs
@@ -65,6 +65,7 @@ connect
 connect host port parser = do
     connHandle  <- connectTo host port
     hSetBinaryMode connHandle True
+    hSetBuffering connHandle (BlockBuffering $ Just 4096)
     rs          <- hGetReplies connHandle parser
     connReplies <- newIORef rs
     connThunks  <- newBoundedChan 1000


### PR DESCRIPTION
This improves pipelining performance. Without BlockBuffering, the handle
defaults to `NoBuffering`, and every `hPut` is immediately digested, i.e.
the `hFlush` in the `unsafeInterleaveIO` section never actually does
anything.

The benchmark program shows an average of 378969.8 pings per second
without this patch, and 629792.5 pings per second with it (both averages
over three runs).

I chose 4096 arbitrarily. We must determine an appropriate value.
