### PR TITLE
Support scans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ appendonly.aof
 *.prof
 /.hpc
 Main.hs
+/cabal.sandbox.config
+/.cabal-sandbox/

--- a/hedis.cabal
+++ b/hedis.cabal
@@ -71,9 +71,10 @@ library
                     Database.Redis.Protocol,
                     Database.Redis.PubSub,
                     Database.Redis.Transactions,
-                    Database.Redis.Types
+                    Database.Redis.Types,
                     Database.Redis.Commands,
-                    Database.Redis.ManualCommands
+                    Database.Redis.ManualCommands,
+                    Database.Redis.Cursors
 
 benchmark hedis-benchmark
     type: exitcode-stdio-1.0
@@ -95,8 +96,8 @@ test-suite hedis-test
         hedis,
         HUnit == 1.2.*,
         mtl == 2.*,
-        test-framework,
-        test-framework-hunit,
+        test-framework >= 0.8,
+        test-framework-hunit >= 0.3,
         time
     -- We use -O0 here, since GHC takes *very* long to compile so many constants
     ghc-options: -O0 -Wall -rtsopts -fno-warn-unused-do-bind

--- a/src/Database/Redis.hs
+++ b/src/Database/Redis.hs
@@ -141,6 +141,9 @@ module Database.Redis (
     
     -- * Transactions
     module Database.Redis.Transactions,
+
+    -- * Cursor support
+    module Database.Redis.Cursors,
     
     -- * Pub\/Sub
     module Database.Redis.PubSub,
@@ -166,6 +169,7 @@ import Database.Redis.PubSub
 import Database.Redis.Protocol
 import Database.Redis.ProtocolPipelining
     (HostName, PortID(..), ConnectionLostException(..))
+import Database.Redis.Cursors
 import Database.Redis.Transactions
 import Database.Redis.Types
 

--- a/src/Database/Redis/Cursors.hs
+++ b/src/Database/Redis/Cursors.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE OverloadedStrings, FlexibleContexts, FlexibleInstances #-}
+
+module Database.Redis.Cursors where
+
+import Data.ByteString (ByteString)
+import Database.Redis.Core
+import Database.Redis.Protocol
+import Database.Redis.Types
+
+scan
+    :: (RedisCtx m f)
+    => ByteString -- ^ cursor
+    -> m (f (ByteString, [ByteString])) -- ^ next cursor and values
+scan cursor =
+    sendRequest ["SCAN", encode cursor]
+
+sscan
+    :: (RedisCtx m f)
+    => ByteString -- ^ key
+    -> ByteString -- ^ cursor
+    -> m (f (ByteString, [ByteString])) -- ^ next cursor and values
+sscan key cursor =
+    sendRequest ["SSCAN", encode key, encode cursor]
+
+zscan
+    :: (RedisCtx m f)
+    => ByteString -- ^ key
+    -> ByteString -- ^ cursor
+    -> m (f (ByteString, [(ByteString, Double)])) -- ^ next cursor and values
+zscan key cursor =
+    sendRequest ["ZSCAN", encode key, encode cursor]
+
+hscan
+    :: (RedisCtx m f)
+    => ByteString -- ^ key
+    -> ByteString -- ^ cursor
+    -> m (f (ByteString, [(ByteString, ByteString)])) -- ^ next cursor and key-value pairs
+hscan key cursor =
+    sendRequest ["HSCAN", encode key, encode cursor]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -54,7 +54,7 @@ tests :: Connection -> [Test.Test]
 tests conn = map ($conn) $ concat
     [ testsMisc, testsKeys, testsStrings, [testHashes], testsLists, testsSets
     , testsZSets, [testPubSub], [testTransaction], [testScripting]
-    , testsConnection, testsServer, [testQuit]
+    , testsConnection, testsServer, [testCursors], [testQuit]
     ]
 
 ------------------------------------------------------------------------------
@@ -139,7 +139,19 @@ testKeys = testCase "keys" $ do
     renamenx "key'" "key" >>=? True
     del ["key"]           >>=? 1
     select 0              >>=? Ok
-    
+
+testCursors :: Test
+testCursors = testCase "cursors" $ do
+    select 4                >>=? Ok
+    set "key" "value"       >>=? Ok
+    scan "0"                >>=? ("0", ["key"])
+    sadd "set" ["1"]        >>=? 1
+    sscan "set" "0"         >>=? ("0", ["1"])
+    hset "hash" "k" "v"     >>=? True
+    hscan "hash" "0"        >>=? ("0", [("k", "v")])
+    zadd "zset" [(42, "2")] >>=? 1
+    zscan "zset" "0"        >>=? ("0", [("2", 42)])
+
 testExpireAt :: Test
 testExpireAt = testCase "expireat" $ do
     set "key" "value"             >>=? Ok


### PR DESCRIPTION
I have added a support for keyspace/set/zset/hmap scan. Interface is very... "raw": it returs a cursor (bytestring) and data itself.

Cursors are implemented in separate module because source generation was too difficult to understand :D

Redis' scans might have optional count and pattern parameters which are not supported in current implementaion.