### PR TITLE
Derive Show instance for ConnectInfo

### DIFF
--- a/src/Database/Redis/Core.hs
+++ b/src/Database/Redis/Core.hs
@@ -131,7 +131,7 @@ data ConnectInfo = ConnInfo
     --   smallest acceptable value is 0.5 seconds. If the @timeout@ value in
     --   your redis.conf file is non-zero, it should be larger than
     --   'connectMaxIdleTime'.
-    }
+    } deriving Show
 
 -- |Default information for connecting:
 --


### PR DESCRIPTION
This PR derives a `Show` instance for `ConnectInfo`, which helps with debugging. My use case was checking code I had written to parse a config file to create a `ConnectInfo`.

Example usage:

```haskell
putStrLn $ "Default connectInfo:" ++ (show defaultConnectInfo)
```

which prints:

```
Default connectInfo:ConnInfo {connectHost = "localhost", connectPort = PortNumber 6379, connectAuth = Nothing, connectDatabase = 0, connectMaxConnections = 50, connectMaxIdleTime = 30s}
```