### PR TITLE
Changed all keys to a newtype

### DIFF
--- a/codegen/GenCmds.hs
+++ b/codegen/GenCmds.hs
@@ -331,6 +331,7 @@ retType Cmd{..} = maybe err translate cmdRetType
         "maybe-string" -> "(Maybe ByteString)"
         "list-string"  -> "[ByteString]"
         "list-maybe"   -> "[Maybe ByteString]"
+        "list-key"     -> "[Key]"
         "list-bool"    -> "[Bool]"
         "hash"         -> "[(ByteString,ByteString)]"
         "set"          -> "[ByteString]"

--- a/codegen/GenCmds.hs
+++ b/codegen/GenCmds.hs
@@ -73,12 +73,12 @@ blacklist = [ manual "AUTH" ["auth"]
                 ["zrangebyscore", "zrangebyscoreWithscores"
                 ,"zrangebyscoreLimit", "zrangebyscoreWithscoresLimit"]
             , manual "ZREVRANGE" ["zrevrange", "zrevrangeWithscores"]
-            , manual "ZREVRANGEBYSCORE" 
+            , manual "ZREVRANGEBYSCORE"
                 ["zrevrangebyscore", "zrevrangebyscoreWithscores"
                 ,"zrevrangebyscoreLimit", "zrevrangebyscoreWithscoresLimit"]
             , manual "ZUNIONSTORE" ["zunionstore","zunionstoreWeights"]
             , unimplemented "MONITOR"        -- debugging command
-            , unimplemented "SYNC"           -- internal command            
+            , unimplemented "SYNC"           -- internal command
             , unimplemented "SHUTDOWN"       -- kills server, throws exception
             , unimplemented "DEBUG SEGFAULT" -- crashes the server
             ]
@@ -151,7 +151,7 @@ instance FromJSON Arg where
             [typ1,typ2]   <- arg .: "type"
             return $ Pair Arg{ argName = name1, argType = typ1 }
                           Arg{ argName = name2, argType = typ2 }
-        -- example: ZREVRANGEBYSCORE 
+        -- example: ZREVRANGEBYSCORE
         parseCommand = do
             s <- arg .: "command"
             return $ Command s
@@ -195,7 +195,7 @@ unimplementedCmds =
         , cmdDescriptionLink cmd
         , fromString ")\n"
         , fromString "--\n"
-        ]                             
+        ]
 
 exportList :: [Cmd] -> Builder
 exportList cmds =
@@ -211,13 +211,13 @@ exportList cmds =
     exportCmd cmd@Cmd{..}
         | implemented cmd = exportCmdNames cmd
         | otherwise       = mempty
-    
+
     implemented Cmd{..} =
         case lookup cmdName blacklist of
             Nothing       -> True
             Just (Just _) -> True
             Just Nothing  -> False
-    
+
     translateGroup Cmd{..} = case cmdGroup of
         "generic"      -> "Keys"
         "string"       -> "Strings"
@@ -237,10 +237,10 @@ exportCmdNames Cmd{..} = types `mappend` functions
   where
     types = mconcat $ flip map typeNames
         (\name -> mconcat [fromString name, fromString ",\n"])
-        
+
     functions = mconcat $ flip map funNames
         (\name -> mconcat [fromString name, fromString ", ", haddock, newline])
-      
+
     funNames = case lookup cmdName blacklist of
         Nothing            -> [camelCase cmdName]
         Just (Just (xs,_)) -> xs
@@ -315,7 +315,7 @@ fromCmd cmd@Cmd{..}
             , fromString " )"
             ]
     name = camelCase cmdName
-    
+
 retType :: Cmd -> Builder
 retType Cmd{..} = maybe err translate cmdRetType
   where
@@ -325,8 +325,8 @@ retType Cmd{..} = maybe err translate cmdRetType
         "bool"         -> "Bool"
         "integer"      -> "Integer"
         "maybe-integer"-> "(Maybe Integer)"
-        "key"          -> "ByteString"
-        "maybe-key"    -> "(Maybe ByteString)"
+        "key"          -> "Key"
+        "maybe-key"    -> "(Maybe Key)"
         "string"       -> "ByteString"
         "maybe-string" -> "(Maybe ByteString)"
         "list-string"  -> "[ByteString]"
@@ -340,7 +340,7 @@ retType Cmd{..} = maybe err translate cmdRetType
         "reply"        -> "Reply"
         "time"         -> "(Integer,Integer)"
         _              -> error $ "untranslated return type: " ++ t
-    
+
 
 argumentList :: Arg -> Builder
 argumentList a = fromString " ++ " `mappend` go a
@@ -376,7 +376,7 @@ argumentType a = mconcat [ go a
     translateArgType Arg{..} = fromString $ case argType of
         "integer"    -> "Integer"
         "string"     -> "ByteString"
-        "key"        -> "ByteString"
+        "key"        -> "Key"
         "pattern"    -> "ByteString"
         "posix time" -> "Integer"
         "double"     -> "Double"
@@ -395,7 +395,7 @@ camelCase s = case split (map toLower s) of
   where
     upcaseFirst []     = ""
     upcaseFirst (c:cs) = toUpper c : cs
-    
+
     -- modified version of Data.List.words
     split s = case dropWhile (not . isAlphaNum) s of
                 "" -> []

--- a/codegen/commands.json
+++ b/codegen/commands.json
@@ -747,7 +747,7 @@
     ],
     "since": "1.0.0",
     "group": "generic",
-    "returns": "list-string"
+    "returns": "list-key"
   },
   "LASTSAVE": {
     "summary": "Get the UNIX time stamp of the last successful save to disk",

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -201,449 +201,51 @@ import Database.Redis.ManualCommands
 import Database.Redis.Types
 import Database.Redis.Core
 
-bgrewriteaof
+ttl
     :: (RedisCtx m f)
-    => m (f Status)
-bgrewriteaof  = sendRequest (["BGREWRITEAOF"] )
-
-sinter
-    :: (RedisCtx m f)
-    => [ByteString] -- ^ key
-    -> m (f [ByteString])
-sinter key = sendRequest (["SINTER"] ++ map encode key )
-
-scriptExists
-    :: (RedisCtx m f)
-    => [ByteString] -- ^ script
-    -> m (f [Bool])
-scriptExists script = sendRequest (["SCRIPT","EXISTS"] ++ map encode script )
-
-sunionstore
-    :: (RedisCtx m f)
-    => ByteString -- ^ destination
-    -> [ByteString] -- ^ key
+    => Key -- ^ key
     -> m (f Integer)
-sunionstore destination key = sendRequest (["SUNIONSTORE"] ++ [encode destination] ++ map encode key )
+ttl key = sendRequest (["TTL"] ++ [encode key] )
 
-setex
+setnx
     :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ seconds
+    => Key -- ^ key
     -> ByteString -- ^ value
-    -> m (f Status)
-setex key seconds value = sendRequest (["SETEX"] ++ [encode key] ++ [encode seconds] ++ [encode value] )
+    -> m (f Bool)
+setnx key value = sendRequest (["SETNX"] ++ [encode key] ++ [encode value] )
 
-hlen
+pttl
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> m (f Integer)
-hlen key = sendRequest (["HLEN"] ++ [encode key] )
+pttl key = sendRequest (["PTTL"] ++ [encode key] )
 
-scard
+zrank
     :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f Integer)
-scard key = sendRequest (["SCARD"] ++ [encode key] )
+    => Key -- ^ key
+    -> ByteString -- ^ member
+    -> m (f (Maybe Integer))
+zrank key member = sendRequest (["ZRANK"] ++ [encode key] ++ [encode member] )
 
 zremrangebyscore
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> Double -- ^ min
     -> Double -- ^ max
     -> m (f Integer)
 zremrangebyscore key min max = sendRequest (["ZREMRANGEBYSCORE"] ++ [encode key] ++ [encode min] ++ [encode max] )
 
-rpushx
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> ByteString -- ^ value
-    -> m (f Integer)
-rpushx key value = sendRequest (["RPUSHX"] ++ [encode key] ++ [encode value] )
-
-spop
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f (Maybe ByteString))
-spop key = sendRequest (["SPOP"] ++ [encode key] )
-
-pttl
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f Integer)
-pttl key = sendRequest (["PTTL"] ++ [encode key] )
-
-rpush
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> [ByteString] -- ^ value
-    -> m (f Integer)
-rpush key value = sendRequest (["RPUSH"] ++ [encode key] ++ map encode value )
-
-debugObject
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f ByteString)
-debugObject key = sendRequest (["DEBUG","OBJECT"] ++ [encode key] )
-
-randomkey
-    :: (RedisCtx m f)
-    => m (f (Maybe ByteString))
-randomkey  = sendRequest (["RANDOMKEY"] )
-
-bgsave
-    :: (RedisCtx m f)
-    => m (f Status)
-bgsave  = sendRequest (["BGSAVE"] )
-
-getrange
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ start
-    -> Integer -- ^ end
-    -> m (f ByteString)
-getrange key start end = sendRequest (["GETRANGE"] ++ [encode key] ++ [encode start] ++ [encode end] )
-
-zcount
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Double -- ^ min
-    -> Double -- ^ max
-    -> m (f Integer)
-zcount key min max = sendRequest (["ZCOUNT"] ++ [encode key] ++ [encode min] ++ [encode max] )
-
-sdiffstore
-    :: (RedisCtx m f)
-    => ByteString -- ^ destination
-    -> [ByteString] -- ^ key
-    -> m (f Integer)
-sdiffstore destination key = sendRequest (["SDIFFSTORE"] ++ [encode destination] ++ map encode key )
-
-blpop
-    :: (RedisCtx m f)
-    => [ByteString] -- ^ key
-    -> Integer -- ^ timeout
-    -> m (f (Maybe (ByteString,ByteString)))
-blpop key timeout = sendRequest (["BLPOP"] ++ map encode key ++ [encode timeout] )
-
-migrate
-    :: (RedisCtx m f)
-    => ByteString -- ^ host
-    -> ByteString -- ^ port
-    -> ByteString -- ^ key
-    -> Integer -- ^ destinationDb
-    -> Integer -- ^ timeout
-    -> m (f Status)
-migrate host port key destinationDb timeout = sendRequest (["MIGRATE"] ++ [encode host] ++ [encode port] ++ [encode key] ++ [encode destinationDb] ++ [encode timeout] )
-
-sismember
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> ByteString -- ^ member
-    -> m (f Bool)
-sismember key member = sendRequest (["SISMEMBER"] ++ [encode key] ++ [encode member] )
-
-incr
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f Integer)
-incr key = sendRequest (["INCR"] ++ [encode key] )
-
-hget
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> ByteString -- ^ field
-    -> m (f (Maybe ByteString))
-hget key field = sendRequest (["HGET"] ++ [encode key] ++ [encode field] )
-
-expireat
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ timestamp
-    -> m (f Bool)
-expireat key timestamp = sendRequest (["EXPIREAT"] ++ [encode key] ++ [encode timestamp] )
-
-info
-    :: (RedisCtx m f)
-    => m (f ByteString)
-info  = sendRequest (["INFO"] )
-
-sdiff
-    :: (RedisCtx m f)
-    => [ByteString] -- ^ key
-    -> m (f [ByteString])
-sdiff key = sendRequest (["SDIFF"] ++ map encode key )
-
-append
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> ByteString -- ^ value
-    -> m (f Integer)
-append key value = sendRequest (["APPEND"] ++ [encode key] ++ [encode value] )
-
-lset
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ index
-    -> ByteString -- ^ value
-    -> m (f Status)
-lset key index value = sendRequest (["LSET"] ++ [encode key] ++ [encode index] ++ [encode value] )
-
-get
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f (Maybe ByteString))
-get key = sendRequest (["GET"] ++ [encode key] )
-
-scriptFlush
-    :: (RedisCtx m f)
-    => m (f Status)
-scriptFlush  = sendRequest (["SCRIPT","FLUSH"] )
-
-lpop
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f (Maybe ByteString))
-lpop key = sendRequest (["LPOP"] ++ [encode key] )
-
-lastsave
-    :: (RedisCtx m f)
-    => m (f Integer)
-lastsave  = sendRequest (["LASTSAVE"] )
-
-dbsize
-    :: (RedisCtx m f)
-    => m (f Integer)
-dbsize  = sendRequest (["DBSIZE"] )
-
-zadd
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> [(Double,ByteString)] -- ^ scoreMember
-    -> m (f Integer)
-zadd key scoreMember = sendRequest (["ZADD"] ++ [encode key] ++ concatMap (\(x,y) -> [encode x,encode y])scoreMember )
-
-hmget
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> [ByteString] -- ^ field
-    -> m (f [Maybe ByteString])
-hmget key field = sendRequest (["HMGET"] ++ [encode key] ++ map encode field )
-
-expire
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ seconds
-    -> m (f Bool)
-expire key seconds = sendRequest (["EXPIRE"] ++ [encode key] ++ [encode seconds] )
-
-mget
-    :: (RedisCtx m f)
-    => [ByteString] -- ^ key
-    -> m (f [Maybe ByteString])
-mget key = sendRequest (["MGET"] ++ map encode key )
-
-hexists
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> ByteString -- ^ field
-    -> m (f Bool)
-hexists key field = sendRequest (["HEXISTS"] ++ [encode key] ++ [encode field] )
-
-exists
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f Bool)
-exists key = sendRequest (["EXISTS"] ++ [encode key] )
-
-sunion
-    :: (RedisCtx m f)
-    => [ByteString] -- ^ key
-    -> m (f [ByteString])
-sunion key = sendRequest (["SUNION"] ++ map encode key )
-
-configSet
-    :: (RedisCtx m f)
-    => ByteString -- ^ parameter
-    -> ByteString -- ^ value
-    -> m (f Status)
-configSet parameter value = sendRequest (["CONFIG","SET"] ++ [encode parameter] ++ [encode value] )
-
-smembers
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f [ByteString])
-smembers key = sendRequest (["SMEMBERS"] ++ [encode key] )
-
-ping
-    :: (RedisCtx m f)
-    => m (f Status)
-ping  = sendRequest (["PING"] )
-
-brpoplpush
-    :: (RedisCtx m f)
-    => ByteString -- ^ source
-    -> ByteString -- ^ destination
-    -> Integer -- ^ timeout
-    -> m (f (Maybe ByteString))
-brpoplpush source destination timeout = sendRequest (["BRPOPLPUSH"] ++ [encode source] ++ [encode destination] ++ [encode timeout] )
-
-rpop
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f (Maybe ByteString))
-rpop key = sendRequest (["RPOP"] ++ [encode key] )
-
-incrbyfloat
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Double -- ^ increment
-    -> m (f Double)
-incrbyfloat key increment = sendRequest (["INCRBYFLOAT"] ++ [encode key] ++ [encode increment] )
-
-setrange
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ offset
-    -> ByteString -- ^ value
-    -> m (f Integer)
-setrange key offset value = sendRequest (["SETRANGE"] ++ [encode key] ++ [encode offset] ++ [encode value] )
-
-hincrbyfloat
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> ByteString -- ^ field
-    -> Double -- ^ increment
-    -> m (f Double)
-hincrbyfloat key field increment = sendRequest (["HINCRBYFLOAT"] ++ [encode key] ++ [encode field] ++ [encode increment] )
-
-zrevrank
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> ByteString -- ^ member
-    -> m (f (Maybe Integer))
-zrevrank key member = sendRequest (["ZREVRANK"] ++ [encode key] ++ [encode member] )
-
-lindex
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ index
-    -> m (f (Maybe ByteString))
-lindex key index = sendRequest (["LINDEX"] ++ [encode key] ++ [encode index] )
-
-sadd
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> [ByteString] -- ^ member
-    -> m (f Integer)
-sadd key member = sendRequest (["SADD"] ++ [encode key] ++ map encode member )
-
-srandmember
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f (Maybe ByteString))
-srandmember key = sendRequest (["SRANDMEMBER"] ++ [encode key] )
-
-zscore
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> ByteString -- ^ member
-    -> m (f (Maybe Double))
-zscore key member = sendRequest (["ZSCORE"] ++ [encode key] ++ [encode member] )
-
-persist
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f Bool)
-persist key = sendRequest (["PERSIST"] ++ [encode key] )
-
-zincrby
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ increment
-    -> ByteString -- ^ member
-    -> m (f Double)
-zincrby key increment member = sendRequest (["ZINCRBY"] ++ [encode key] ++ [encode increment] ++ [encode member] )
-
-rpoplpush
-    :: (RedisCtx m f)
-    => ByteString -- ^ source
-    -> ByteString -- ^ destination
-    -> m (f (Maybe ByteString))
-rpoplpush source destination = sendRequest (["RPOPLPUSH"] ++ [encode source] ++ [encode destination] )
-
-hgetall
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f [(ByteString,ByteString)])
-hgetall key = sendRequest (["HGETALL"] ++ [encode key] )
-
-mset
-    :: (RedisCtx m f)
-    => [(ByteString,ByteString)] -- ^ keyValue
-    -> m (f Status)
-mset keyValue = sendRequest (["MSET"] ++ concatMap (\(x,y) -> [encode x,encode y])keyValue )
-
-hmset
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> [(ByteString,ByteString)] -- ^ fieldValue
-    -> m (f Status)
-hmset key fieldValue = sendRequest (["HMSET"] ++ [encode key] ++ concatMap (\(x,y) -> [encode x,encode y])fieldValue )
-
-psetex
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ milliseconds
-    -> ByteString -- ^ value
-    -> m (f Status)
-psetex key milliseconds value = sendRequest (["PSETEX"] ++ [encode key] ++ [encode milliseconds] ++ [encode value] )
-
-brpop
-    :: (RedisCtx m f)
-    => [ByteString] -- ^ key
-    -> Integer -- ^ timeout
-    -> m (f (Maybe (ByteString,ByteString)))
-brpop key timeout = sendRequest (["BRPOP"] ++ map encode key ++ [encode timeout] )
-
-hsetnx
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> ByteString -- ^ field
-    -> ByteString -- ^ value
-    -> m (f Bool)
-hsetnx key field value = sendRequest (["HSETNX"] ++ [encode key] ++ [encode field] ++ [encode value] )
-
-configGet
-    :: (RedisCtx m f)
-    => ByteString -- ^ parameter
-    -> m (f [(ByteString,ByteString)])
-configGet parameter = sendRequest (["CONFIG","GET"] ++ [encode parameter] )
-
-zrank
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> ByteString -- ^ member
-    -> m (f (Maybe Integer))
-zrank key member = sendRequest (["ZRANK"] ++ [encode key] ++ [encode member] )
-
 hkeys
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> m (f [ByteString])
 hkeys key = sendRequest (["HKEYS"] ++ [encode key] )
 
-ttl
+spop
     :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f Integer)
-ttl key = sendRequest (["TTL"] ++ [encode key] )
-
-getset
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> ByteString -- ^ value
+    => Key -- ^ key
     -> m (f (Maybe ByteString))
-getset key value = sendRequest (["GETSET"] ++ [encode key] ++ [encode value] )
+spop key = sendRequest (["SPOP"] ++ [encode key] )
 
 slaveof
     :: (RedisCtx m f)
@@ -652,16 +254,341 @@ slaveof
     -> m (f Status)
 slaveof host port = sendRequest (["SLAVEOF"] ++ [encode host] ++ [encode port] )
 
-setnx
+rpushx
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> ByteString -- ^ value
+    -> m (f Integer)
+rpushx key value = sendRequest (["RPUSHX"] ++ [encode key] ++ [encode value] )
+
+debugObject
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> m (f ByteString)
+debugObject key = sendRequest (["DEBUG","OBJECT"] ++ [encode key] )
+
+bgsave
+    :: (RedisCtx m f)
+    => m (f Status)
+bgsave  = sendRequest (["BGSAVE"] )
+
+hlen
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> m (f Integer)
+hlen key = sendRequest (["HLEN"] ++ [encode key] )
+
+rpoplpush
+    :: (RedisCtx m f)
+    => Key -- ^ source
+    -> Key -- ^ destination
+    -> m (f (Maybe ByteString))
+rpoplpush source destination = sendRequest (["RPOPLPUSH"] ++ [encode source] ++ [encode destination] )
+
+brpop
+    :: (RedisCtx m f)
+    => [Key] -- ^ key
+    -> Integer -- ^ timeout
+    -> m (f (Maybe (ByteString,ByteString)))
+brpop key timeout = sendRequest (["BRPOP"] ++ map encode key ++ [encode timeout] )
+
+bgrewriteaof
+    :: (RedisCtx m f)
+    => m (f Status)
+bgrewriteaof  = sendRequest (["BGREWRITEAOF"] )
+
+zincrby
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Integer -- ^ increment
+    -> ByteString -- ^ member
+    -> m (f Double)
+zincrby key increment member = sendRequest (["ZINCRBY"] ++ [encode key] ++ [encode increment] ++ [encode member] )
+
+hgetall
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> m (f [(ByteString,ByteString)])
+hgetall key = sendRequest (["HGETALL"] ++ [encode key] )
+
+hmset
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> [(ByteString,ByteString)] -- ^ fieldValue
+    -> m (f Status)
+hmset key fieldValue = sendRequest (["HMSET"] ++ [encode key] ++ concatMap (\(x,y) -> [encode x,encode y])fieldValue )
+
+sinter
+    :: (RedisCtx m f)
+    => [Key] -- ^ key
+    -> m (f [ByteString])
+sinter key = sendRequest (["SINTER"] ++ map encode key )
+
+zremrangebyrank
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Integer -- ^ start
+    -> Integer -- ^ stop
+    -> m (f Integer)
+zremrangebyrank key start stop = sendRequest (["ZREMRANGEBYRANK"] ++ [encode key] ++ [encode start] ++ [encode stop] )
+
+flushdb
+    :: (RedisCtx m f)
+    => m (f Status)
+flushdb  = sendRequest (["FLUSHDB"] )
+
+sadd
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> [ByteString] -- ^ member
+    -> m (f Integer)
+sadd key member = sendRequest (["SADD"] ++ [encode key] ++ map encode member )
+
+lindex
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Integer -- ^ index
+    -> m (f (Maybe ByteString))
+lindex key index = sendRequest (["LINDEX"] ++ [encode key] ++ [encode index] )
+
+set
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> ByteString -- ^ value
+    -> m (f Status)
+set key value = sendRequest (["SET"] ++ [encode key] ++ [encode value] )
+
+lpush
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> [ByteString] -- ^ value
+    -> m (f Integer)
+lpush key value = sendRequest (["LPUSH"] ++ [encode key] ++ map encode value )
+
+smove
+    :: (RedisCtx m f)
+    => Key -- ^ source
+    -> Key -- ^ destination
+    -> ByteString -- ^ member
     -> m (f Bool)
-setnx key value = sendRequest (["SETNX"] ++ [encode key] ++ [encode value] )
+smove source destination member = sendRequest (["SMOVE"] ++ [encode source] ++ [encode destination] ++ [encode member] )
+
+zscore
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> ByteString -- ^ member
+    -> m (f (Maybe Double))
+zscore key member = sendRequest (["ZSCORE"] ++ [encode key] ++ [encode member] )
+
+configResetstat
+    :: (RedisCtx m f)
+    => m (f Status)
+configResetstat  = sendRequest (["CONFIG","RESETSTAT"] )
+
+hdel
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> [ByteString] -- ^ field
+    -> m (f Integer)
+hdel key field = sendRequest (["HDEL"] ++ [encode key] ++ map encode field )
+
+incrbyfloat
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Double -- ^ increment
+    -> m (f Double)
+incrbyfloat key increment = sendRequest (["INCRBYFLOAT"] ++ [encode key] ++ [encode increment] )
+
+setbit
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Integer -- ^ offset
+    -> ByteString -- ^ value
+    -> m (f Integer)
+setbit key offset value = sendRequest (["SETBIT"] ++ [encode key] ++ [encode offset] ++ [encode value] )
+
+flushall
+    :: (RedisCtx m f)
+    => m (f Status)
+flushall  = sendRequest (["FLUSHALL"] )
+
+incrby
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Integer -- ^ increment
+    -> m (f Integer)
+incrby key increment = sendRequest (["INCRBY"] ++ [encode key] ++ [encode increment] )
+
+time
+    :: (RedisCtx m f)
+    => m (f (Integer,Integer))
+time  = sendRequest (["TIME"] )
+
+smembers
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> m (f [ByteString])
+smembers key = sendRequest (["SMEMBERS"] ++ [encode key] )
+
+exists
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> m (f Bool)
+exists key = sendRequest (["EXISTS"] ++ [encode key] )
+
+sunion
+    :: (RedisCtx m f)
+    => [Key] -- ^ key
+    -> m (f [ByteString])
+sunion key = sendRequest (["SUNION"] ++ map encode key )
+
+sinterstore
+    :: (RedisCtx m f)
+    => Key -- ^ destination
+    -> [Key] -- ^ key
+    -> m (f Integer)
+sinterstore destination key = sendRequest (["SINTERSTORE"] ++ [encode destination] ++ map encode key )
+
+ping
+    :: (RedisCtx m f)
+    => m (f Status)
+ping  = sendRequest (["PING"] )
+
+hvals
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> m (f [ByteString])
+hvals key = sendRequest (["HVALS"] ++ [encode key] )
+
+configSet
+    :: (RedisCtx m f)
+    => ByteString -- ^ parameter
+    -> ByteString -- ^ value
+    -> m (f Status)
+configSet parameter value = sendRequest (["CONFIG","SET"] ++ [encode parameter] ++ [encode value] )
+
+restore
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Integer -- ^ timeToLive
+    -> ByteString -- ^ serializedValue
+    -> m (f Status)
+restore key timeToLive serializedValue = sendRequest (["RESTORE"] ++ [encode key] ++ [encode timeToLive] ++ [encode serializedValue] )
+
+scriptFlush
+    :: (RedisCtx m f)
+    => m (f Status)
+scriptFlush  = sendRequest (["SCRIPT","FLUSH"] )
+
+dbsize
+    :: (RedisCtx m f)
+    => m (f Integer)
+dbsize  = sendRequest (["DBSIZE"] )
+
+lpop
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> m (f (Maybe ByteString))
+lpop key = sendRequest (["LPOP"] ++ [encode key] )
+
+expire
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Integer -- ^ seconds
+    -> m (f Bool)
+expire key seconds = sendRequest (["EXPIRE"] ++ [encode key] ++ [encode seconds] )
+
+mget
+    :: (RedisCtx m f)
+    => [Key] -- ^ key
+    -> m (f [Maybe ByteString])
+mget key = sendRequest (["MGET"] ++ map encode key )
+
+lastsave
+    :: (RedisCtx m f)
+    => m (f Integer)
+lastsave  = sendRequest (["LASTSAVE"] )
+
+zadd
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> [(Double,ByteString)] -- ^ scoreMember
+    -> m (f Integer)
+zadd key scoreMember = sendRequest (["ZADD"] ++ [encode key] ++ concatMap (\(x,y) -> [encode x,encode y])scoreMember )
+
+pexpire
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Integer -- ^ milliseconds
+    -> m (f Bool)
+pexpire key milliseconds = sendRequest (["PEXPIRE"] ++ [encode key] ++ [encode milliseconds] )
+
+renamenx
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Key -- ^ newkey
+    -> m (f Bool)
+renamenx key newkey = sendRequest (["RENAMENX"] ++ [encode key] ++ [encode newkey] )
+
+lrem
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Integer -- ^ count
+    -> ByteString -- ^ value
+    -> m (f Integer)
+lrem key count value = sendRequest (["LREM"] ++ [encode key] ++ [encode count] ++ [encode value] )
+
+sdiff
+    :: (RedisCtx m f)
+    => [Key] -- ^ key
+    -> m (f [ByteString])
+sdiff key = sendRequest (["SDIFF"] ++ map encode key )
+
+get
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> m (f (Maybe ByteString))
+get key = sendRequest (["GET"] ++ [encode key] )
+
+getrange
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Integer -- ^ start
+    -> Integer -- ^ end
+    -> m (f ByteString)
+getrange key start end = sendRequest (["GETRANGE"] ++ [encode key] ++ [encode start] ++ [encode end] )
+
+sdiffstore
+    :: (RedisCtx m f)
+    => Key -- ^ destination
+    -> [Key] -- ^ key
+    -> m (f Integer)
+sdiffstore destination key = sendRequest (["SDIFFSTORE"] ++ [encode destination] ++ map encode key )
+
+zcount
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Double -- ^ min
+    -> Double -- ^ max
+    -> m (f Integer)
+zcount key min max = sendRequest (["ZCOUNT"] ++ [encode key] ++ [encode min] ++ [encode max] )
+
+scriptLoad
+    :: (RedisCtx m f)
+    => ByteString -- ^ script
+    -> m (f ByteString)
+scriptLoad script = sendRequest (["SCRIPT","LOAD"] ++ [encode script] )
+
+getset
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> ByteString -- ^ value
+    -> m (f (Maybe ByteString))
+getset key value = sendRequest (["GETSET"] ++ [encode key] ++ [encode value] )
 
 dump
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> m (f ByteString)
 dump key = sendRequest (["DUMP"] ++ [encode key] )
 
@@ -671,271 +598,344 @@ keys
     -> m (f [ByteString])
 keys pattern = sendRequest (["KEYS"] ++ [encode pattern] )
 
-echo
+configGet
     :: (RedisCtx m f)
-    => ByteString -- ^ message
-    -> m (f ByteString)
-echo message = sendRequest (["ECHO"] ++ [encode message] )
+    => ByteString -- ^ parameter
+    -> m (f [(ByteString,ByteString)])
+configGet parameter = sendRequest (["CONFIG","GET"] ++ [encode parameter] )
 
-getbit
+rpush
     :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ offset
+    => Key -- ^ key
+    -> [ByteString] -- ^ value
     -> m (f Integer)
-getbit key offset = sendRequest (["GETBIT"] ++ [encode key] ++ [encode offset] )
+rpush key value = sendRequest (["RPUSH"] ++ [encode key] ++ map encode value )
 
-quit
+randomkey
     :: (RedisCtx m f)
-    => m (f Status)
-quit  = sendRequest (["QUIT"] )
+    => m (f (Maybe Key))
+randomkey  = sendRequest (["RANDOMKEY"] )
 
-srem
+hsetnx
     :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> [ByteString] -- ^ member
-    -> m (f Integer)
-srem key member = sendRequest (["SREM"] ++ [encode key] ++ map encode member )
-
-move
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ db
-    -> m (f Bool)
-move key db = sendRequest (["MOVE"] ++ [encode key] ++ [encode db] )
-
-scriptLoad
-    :: (RedisCtx m f)
-    => ByteString -- ^ script
-    -> m (f ByteString)
-scriptLoad script = sendRequest (["SCRIPT","LOAD"] ++ [encode script] )
-
-msetnx
-    :: (RedisCtx m f)
-    => [(ByteString,ByteString)] -- ^ keyValue
-    -> m (f Bool)
-msetnx keyValue = sendRequest (["MSETNX"] ++ concatMap (\(x,y) -> [encode x,encode y])keyValue )
-
-save
-    :: (RedisCtx m f)
-    => m (f Status)
-save  = sendRequest (["SAVE"] )
-
-ltrim
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ start
-    -> Integer -- ^ stop
-    -> m (f Status)
-ltrim key start stop = sendRequest (["LTRIM"] ++ [encode key] ++ [encode start] ++ [encode stop] )
-
-lrem
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ count
+    => Key -- ^ key
+    -> ByteString -- ^ field
     -> ByteString -- ^ value
-    -> m (f Integer)
-lrem key count value = sendRequest (["LREM"] ++ [encode key] ++ [encode count] ++ [encode value] )
-
-pexpireat
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ millisecondsTimestamp
     -> m (f Bool)
-pexpireat key millisecondsTimestamp = sendRequest (["PEXPIREAT"] ++ [encode key] ++ [encode millisecondsTimestamp] )
+hsetnx key field value = sendRequest (["HSETNX"] ++ [encode key] ++ [encode field] ++ [encode value] )
 
-zcard
+mset
     :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f Integer)
-zcard key = sendRequest (["ZCARD"] ++ [encode key] )
+    => [(Key,ByteString)] -- ^ keyValue
+    -> m (f Status)
+mset keyValue = sendRequest (["MSET"] ++ concatMap (\(x,y) -> [encode x,encode y])keyValue )
 
-renamenx
+setex
     :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> ByteString -- ^ newkey
-    -> m (f Bool)
-renamenx key newkey = sendRequest (["RENAMENX"] ++ [encode key] ++ [encode newkey] )
+    => Key -- ^ key
+    -> Integer -- ^ seconds
+    -> ByteString -- ^ value
+    -> m (f Status)
+setex key seconds value = sendRequest (["SETEX"] ++ [encode key] ++ [encode seconds] ++ [encode value] )
 
-llen
+psetex
     :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f Integer)
-llen key = sendRequest (["LLEN"] ++ [encode key] )
-
-pexpire
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> Integer -- ^ milliseconds
+    -> ByteString -- ^ value
+    -> m (f Status)
+psetex key milliseconds value = sendRequest (["PSETEX"] ++ [encode key] ++ [encode milliseconds] ++ [encode value] )
+
+scard
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> m (f Integer)
+scard key = sendRequest (["SCARD"] ++ [encode key] )
+
+scriptExists
+    :: (RedisCtx m f)
+    => [ByteString] -- ^ script
+    -> m (f [Bool])
+scriptExists script = sendRequest (["SCRIPT","EXISTS"] ++ map encode script )
+
+sunionstore
+    :: (RedisCtx m f)
+    => Key -- ^ destination
+    -> [Key] -- ^ key
+    -> m (f Integer)
+sunionstore destination key = sendRequest (["SUNIONSTORE"] ++ [encode destination] ++ map encode key )
+
+persist
+    :: (RedisCtx m f)
+    => Key -- ^ key
     -> m (f Bool)
-pexpire key milliseconds = sendRequest (["PEXPIRE"] ++ [encode key] ++ [encode milliseconds] )
+persist key = sendRequest (["PERSIST"] ++ [encode key] )
 
-decrby
+strlen
     :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ decrement
+    => Key -- ^ key
     -> m (f Integer)
-decrby key decrement = sendRequest (["DECRBY"] ++ [encode key] ++ [encode decrement] )
+strlen key = sendRequest (["STRLEN"] ++ [encode key] )
 
-lrange
+lpushx
     :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ start
-    -> Integer -- ^ stop
-    -> m (f [ByteString])
-lrange key start stop = sendRequest (["LRANGE"] ++ [encode key] ++ [encode start] ++ [encode stop] )
-
-sinterstore
-    :: (RedisCtx m f)
-    => ByteString -- ^ destination
-    -> [ByteString] -- ^ key
-    -> m (f Integer)
-sinterstore destination key = sendRequest (["SINTERSTORE"] ++ [encode destination] ++ map encode key )
-
-rename
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> ByteString -- ^ newkey
-    -> m (f Status)
-rename key newkey = sendRequest (["RENAME"] ++ [encode key] ++ [encode newkey] )
-
-restore
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ timeToLive
-    -> ByteString -- ^ serializedValue
-    -> m (f Status)
-restore key timeToLive serializedValue = sendRequest (["RESTORE"] ++ [encode key] ++ [encode timeToLive] ++ [encode serializedValue] )
-
-hvals
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f [ByteString])
-hvals key = sendRequest (["HVALS"] ++ [encode key] )
-
-zrem
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> [ByteString] -- ^ member
-    -> m (f Integer)
-zrem key member = sendRequest (["ZREM"] ++ [encode key] ++ map encode member )
-
-decr
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f Integer)
-decr key = sendRequest (["DECR"] ++ [encode key] )
-
-configResetstat
-    :: (RedisCtx m f)
-    => m (f Status)
-configResetstat  = sendRequest (["CONFIG","RESETSTAT"] )
-
-flushall
-    :: (RedisCtx m f)
-    => m (f Status)
-flushall  = sendRequest (["FLUSHALL"] )
-
-hdel
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> [ByteString] -- ^ field
-    -> m (f Integer)
-hdel key field = sendRequest (["HDEL"] ++ [encode key] ++ map encode field )
-
-setbit
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ offset
+    => Key -- ^ key
     -> ByteString -- ^ value
     -> m (f Integer)
-setbit key offset value = sendRequest (["SETBIT"] ++ [encode key] ++ [encode offset] ++ [encode value] )
+lpushx key value = sendRequest (["LPUSHX"] ++ [encode key] ++ [encode value] )
 
-del
+srandmember
     :: (RedisCtx m f)
-    => [ByteString] -- ^ key
-    -> m (f Integer)
-del key = sendRequest (["DEL"] ++ map encode key )
+    => Key -- ^ key
+    -> m (f (Maybe ByteString))
+srandmember key = sendRequest (["SRANDMEMBER"] ++ [encode key] )
+
+hset
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> ByteString -- ^ field
+    -> ByteString -- ^ value
+    -> m (f Bool)
+hset key field value = sendRequest (["HSET"] ++ [encode key] ++ [encode field] ++ [encode value] )
+
+brpoplpush
+    :: (RedisCtx m f)
+    => Key -- ^ source
+    -> Key -- ^ destination
+    -> Integer -- ^ timeout
+    -> m (f (Maybe ByteString))
+brpoplpush source destination timeout = sendRequest (["BRPOPLPUSH"] ++ [encode source] ++ [encode destination] ++ [encode timeout] )
+
+zrevrank
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> ByteString -- ^ member
+    -> m (f (Maybe Integer))
+zrevrank key member = sendRequest (["ZREVRANK"] ++ [encode key] ++ [encode member] )
 
 scriptKill
     :: (RedisCtx m f)
     => m (f Status)
 scriptKill  = sendRequest (["SCRIPT","KILL"] )
 
-incrby
+setrange
     :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> Integer -- ^ increment
+    => Key -- ^ key
+    -> Integer -- ^ offset
+    -> ByteString -- ^ value
     -> m (f Integer)
-incrby key increment = sendRequest (["INCRBY"] ++ [encode key] ++ [encode increment] )
+setrange key offset value = sendRequest (["SETRANGE"] ++ [encode key] ++ [encode offset] ++ [encode value] )
+
+del
+    :: (RedisCtx m f)
+    => [Key] -- ^ key
+    -> m (f Integer)
+del key = sendRequest (["DEL"] ++ map encode key )
+
+hincrbyfloat
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> ByteString -- ^ field
+    -> Double -- ^ increment
+    -> m (f Double)
+hincrbyfloat key field increment = sendRequest (["HINCRBYFLOAT"] ++ [encode key] ++ [encode field] ++ [encode increment] )
 
 hincrby
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> ByteString -- ^ field
     -> Integer -- ^ increment
     -> m (f Integer)
 hincrby key field increment = sendRequest (["HINCRBY"] ++ [encode key] ++ [encode field] ++ [encode increment] )
 
-time
+rpop
     :: (RedisCtx m f)
-    => m (f (Integer,Integer))
-time  = sendRequest (["TIME"] )
+    => Key -- ^ key
+    -> m (f (Maybe ByteString))
+rpop key = sendRequest (["RPOP"] ++ [encode key] )
 
-hset
+rename
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
+    -> Key -- ^ newkey
+    -> m (f Status)
+rename key newkey = sendRequest (["RENAME"] ++ [encode key] ++ [encode newkey] )
+
+zrem
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> [ByteString] -- ^ member
+    -> m (f Integer)
+zrem key member = sendRequest (["ZREM"] ++ [encode key] ++ map encode member )
+
+hexists
+    :: (RedisCtx m f)
+    => Key -- ^ key
     -> ByteString -- ^ field
-    -> ByteString -- ^ value
     -> m (f Bool)
-hset key field value = sendRequest (["HSET"] ++ [encode key] ++ [encode field] ++ [encode value] )
+hexists key field = sendRequest (["HEXISTS"] ++ [encode key] ++ [encode field] )
 
-strlen
+decr
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> m (f Integer)
-strlen key = sendRequest (["STRLEN"] ++ [encode key] )
+decr key = sendRequest (["DECR"] ++ [encode key] )
 
-flushdb
+hmget
     :: (RedisCtx m f)
-    => m (f Status)
-flushdb  = sendRequest (["FLUSHDB"] )
+    => Key -- ^ key
+    -> [ByteString] -- ^ field
+    -> m (f [Maybe ByteString])
+hmget key field = sendRequest (["HMGET"] ++ [encode key] ++ map encode field )
 
-lpushx
+lrange
     :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> ByteString -- ^ value
-    -> m (f Integer)
-lpushx key value = sendRequest (["LPUSHX"] ++ [encode key] ++ [encode value] )
-
-smove
-    :: (RedisCtx m f)
-    => ByteString -- ^ source
-    -> ByteString -- ^ destination
-    -> ByteString -- ^ member
-    -> m (f Bool)
-smove source destination member = sendRequest (["SMOVE"] ++ [encode source] ++ [encode destination] ++ [encode member] )
-
-zremrangebyrank
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> Integer -- ^ start
     -> Integer -- ^ stop
-    -> m (f Integer)
-zremrangebyrank key start stop = sendRequest (["ZREMRANGEBYRANK"] ++ [encode key] ++ [encode start] ++ [encode stop] )
+    -> m (f [ByteString])
+lrange key start stop = sendRequest (["LRANGE"] ++ [encode key] ++ [encode start] ++ [encode stop] )
 
-set
+decrby
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
+    -> Integer -- ^ decrement
+    -> m (f Integer)
+decrby key decrement = sendRequest (["DECRBY"] ++ [encode key] ++ [encode decrement] )
+
+llen
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> m (f Integer)
+llen key = sendRequest (["LLEN"] ++ [encode key] )
+
+append
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> ByteString -- ^ value
+    -> m (f Integer)
+append key value = sendRequest (["APPEND"] ++ [encode key] ++ [encode value] )
+
+incr
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> m (f Integer)
+incr key = sendRequest (["INCR"] ++ [encode key] )
+
+hget
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> ByteString -- ^ field
+    -> m (f (Maybe ByteString))
+hget key field = sendRequest (["HGET"] ++ [encode key] ++ [encode field] )
+
+pexpireat
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Integer -- ^ millisecondsTimestamp
+    -> m (f Bool)
+pexpireat key millisecondsTimestamp = sendRequest (["PEXPIREAT"] ++ [encode key] ++ [encode millisecondsTimestamp] )
+
+ltrim
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Integer -- ^ start
+    -> Integer -- ^ stop
+    -> m (f Status)
+ltrim key start stop = sendRequest (["LTRIM"] ++ [encode key] ++ [encode start] ++ [encode stop] )
+
+info
+    :: (RedisCtx m f)
+    => m (f ByteString)
+info  = sendRequest (["INFO"] )
+
+zcard
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> m (f Integer)
+zcard key = sendRequest (["ZCARD"] ++ [encode key] )
+
+lset
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Integer -- ^ index
     -> ByteString -- ^ value
     -> m (f Status)
-set key value = sendRequest (["SET"] ++ [encode key] ++ [encode value] )
+lset key index value = sendRequest (["LSET"] ++ [encode key] ++ [encode index] ++ [encode value] )
 
-lpush
+expireat
     :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> [ByteString] -- ^ value
+    => Key -- ^ key
+    -> Integer -- ^ timestamp
+    -> m (f Bool)
+expireat key timestamp = sendRequest (["EXPIREAT"] ++ [encode key] ++ [encode timestamp] )
+
+save
+    :: (RedisCtx m f)
+    => m (f Status)
+save  = sendRequest (["SAVE"] )
+
+move
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Integer -- ^ db
+    -> m (f Bool)
+move key db = sendRequest (["MOVE"] ++ [encode key] ++ [encode db] )
+
+getbit
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> Integer -- ^ offset
     -> m (f Integer)
-lpush key value = sendRequest (["LPUSH"] ++ [encode key] ++ map encode value )
+getbit key offset = sendRequest (["GETBIT"] ++ [encode key] ++ [encode offset] )
+
+msetnx
+    :: (RedisCtx m f)
+    => [(Key,ByteString)] -- ^ keyValue
+    -> m (f Bool)
+msetnx keyValue = sendRequest (["MSETNX"] ++ concatMap (\(x,y) -> [encode x,encode y])keyValue )
+
+quit
+    :: (RedisCtx m f)
+    => m (f Status)
+quit  = sendRequest (["QUIT"] )
+
+blpop
+    :: (RedisCtx m f)
+    => [Key] -- ^ key
+    -> Integer -- ^ timeout
+    -> m (f (Maybe (ByteString,ByteString)))
+blpop key timeout = sendRequest (["BLPOP"] ++ map encode key ++ [encode timeout] )
+
+srem
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> [ByteString] -- ^ member
+    -> m (f Integer)
+srem key member = sendRequest (["SREM"] ++ [encode key] ++ map encode member )
+
+echo
+    :: (RedisCtx m f)
+    => ByteString -- ^ message
+    -> m (f ByteString)
+echo message = sendRequest (["ECHO"] ++ [encode message] )
+
+sismember
+    :: (RedisCtx m f)
+    => Key -- ^ key
+    -> ByteString -- ^ member
+    -> m (f Bool)
+sismember key member = sendRequest (["SISMEMBER"] ++ [encode key] ++ [encode member] )
+
+migrate
+    :: (RedisCtx m f)
+    => ByteString -- ^ host
+    -> ByteString -- ^ port
+    -> Key -- ^ key
+    -> Integer -- ^ destinationDb
+    -> Integer -- ^ timeout
+    -> m (f Status)
+migrate host port key destinationDb timeout = sendRequest (["MIGRATE"] ++ [encode host] ++ [encode port] ++ [encode key] ++ [encode destinationDb] ++ [encode timeout] )
 
 
 

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -595,7 +595,7 @@ dump key = sendRequest (["DUMP"] ++ [encode key] )
 keys
     :: (RedisCtx m f)
     => ByteString -- ^ pattern
-    -> m (f [ByteString])
+    -> m (f [Key])
 keys pattern = sendRequest (["KEYS"] ++ [encode pattern] )
 
 configGet

--- a/src/Database/Redis/ManualCommands.hs
+++ b/src/Database/Redis/ManualCommands.hs
@@ -11,25 +11,25 @@ import Database.Redis.Types
 
 objectRefcount
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> m (f Integer)
 objectRefcount key = sendRequest ["OBJECT", "refcount", encode key]
 
 objectIdletime
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> m (f Integer)
 objectIdletime key = sendRequest ["OBJECT", "idletime", encode key]
 
 objectEncoding
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> m (f ByteString)
 objectEncoding key = sendRequest ["OBJECT", "encoding", encode key]
 
 linsertBefore
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> ByteString -- ^ pivot
     -> ByteString -- ^ value
     -> m (f Integer)
@@ -38,7 +38,7 @@ linsertBefore key pivot value =
 
 linsertAfter
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> ByteString -- ^ pivot
     -> ByteString -- ^ value
     -> m (f Integer)
@@ -47,7 +47,7 @@ linsertAfter key pivot value =
 
 getType
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> m (f RedisType)
 getType key = sendRequest ["TYPE", encode key]
 
@@ -86,7 +86,7 @@ slowlogReset = sendRequest ["SLOWLOG", "RESET"]
 
 zrange
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> Integer -- ^ start
     -> Integer -- ^ stop
     -> m (f [ByteString])
@@ -95,7 +95,7 @@ zrange key start stop =
 
 zrangeWithscores
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> Integer -- ^ start
     -> Integer -- ^ stop
     -> m (f [(ByteString, Double)])
@@ -104,7 +104,7 @@ zrangeWithscores key start stop =
 
 zrevrange
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> Integer -- ^ start
     -> Integer -- ^ stop
     -> m (f [ByteString])
@@ -113,7 +113,7 @@ zrevrange key start stop =
 
 zrevrangeWithscores
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> Integer -- ^ start
     -> Integer -- ^ stop
     -> m (f [(ByteString, Double)])
@@ -123,7 +123,7 @@ zrevrangeWithscores key start stop =
 
 zrangebyscore
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> Double -- ^ min
     -> Double -- ^ max
     -> m (f [ByteString])
@@ -132,7 +132,7 @@ zrangebyscore key min max =
 
 zrangebyscoreWithscores
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> Double -- ^ min
     -> Double -- ^ max
     -> m (f [(ByteString, Double)])
@@ -142,7 +142,7 @@ zrangebyscoreWithscores key min max =
 
 zrangebyscoreLimit
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> Double -- ^ min
     -> Double -- ^ max
     -> Integer -- ^ offset
@@ -154,7 +154,7 @@ zrangebyscoreLimit key min max offset count =
 
 zrangebyscoreWithscoresLimit
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> Double -- ^ min
     -> Double -- ^ max
     -> Integer -- ^ offset
@@ -166,7 +166,7 @@ zrangebyscoreWithscoresLimit key min max offset count =
 
 zrevrangebyscore
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> Double -- ^ max
     -> Double -- ^ min
     -> m (f [ByteString])
@@ -175,7 +175,7 @@ zrevrangebyscore key min max =
 
 zrevrangebyscoreWithscores
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> Double -- ^ max
     -> Double -- ^ min
     -> m (f [(ByteString, Double)])
@@ -185,7 +185,7 @@ zrevrangebyscoreWithscores key min max =
 
 zrevrangebyscoreLimit
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> Double -- ^ max
     -> Double -- ^ min
     -> Integer -- ^ offset
@@ -197,7 +197,7 @@ zrevrangebyscoreLimit key min max offset count =
 
 zrevrangebyscoreWithscoresLimit
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> Double -- ^ max
     -> Double -- ^ min
     -> Integer -- ^ offset
@@ -241,7 +241,7 @@ data SortOrder = Asc | Desc deriving (Show, Eq)
 
 sortStore
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> ByteString -- ^ destination
     -> SortOpts
     -> m (f Integer)
@@ -249,14 +249,14 @@ sortStore key dest = sortInternal key (Just dest)
 
 sort
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> SortOpts
     -> m (f [ByteString])
 sort key = sortInternal key Nothing
 
 sortInternal
     :: (RedisResult a, RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> Maybe ByteString -- ^ destination
     -> SortOpts
     -> m (f a)
@@ -276,7 +276,7 @@ data Aggregate = Sum | Min | Max deriving (Show,Eq)
 zunionstore
     :: (RedisCtx m f)
     => ByteString -- ^ destination
-    -> [ByteString] -- ^ keys
+    -> [Key] -- ^ keys
     -> Aggregate
     -> m (f Integer)
 zunionstore dest keys =
@@ -285,7 +285,7 @@ zunionstore dest keys =
 zunionstoreWeights
     :: (RedisCtx m f)
     => ByteString -- ^ destination
-    -> [(ByteString,Double)] -- ^ weighted keys
+    -> [(Key,Double)] -- ^ weighted keys
     -> Aggregate
     -> m (f Integer)
 zunionstoreWeights dest kws =
@@ -295,7 +295,7 @@ zunionstoreWeights dest kws =
 zinterstore
     :: (RedisCtx m f)
     => ByteString -- ^ destination
-    -> [ByteString] -- ^ keys
+    -> [Key] -- ^ keys
     -> Aggregate
     -> m (f Integer)
 zinterstore dest keys =
@@ -304,7 +304,7 @@ zinterstore dest keys =
 zinterstoreWeights
     :: (RedisCtx m f)
     => ByteString -- ^ destination
-    -> [(ByteString,Double)] -- ^ weighted keys
+    -> [(Key,Double)] -- ^ weighted keys
     -> Aggregate
     -> m (f Integer)
 zinterstoreWeights dest kws =
@@ -315,12 +315,12 @@ zstoreInternal
     :: (RedisCtx m f)
     => ByteString -- ^ cmd
     -> ByteString -- ^ destination
-    -> [ByteString] -- ^ keys
+    -> [Key] -- ^ keys
     -> [Double] -- ^ weights
-    -> Aggregate    
+    -> Aggregate
     -> m (f Integer)
 zstoreInternal cmd dest keys weights aggregate = sendRequest $
-    concat [ [cmd, dest, encode . toInteger $ length keys], keys
+    concat [ [cmd, dest, encode . toInteger $ length keys], fmap encode keys
            , if null weights then [] else "WEIGHTS" : map encode weights
            , ["AGGREGATE", aggregate']
            ]
@@ -333,71 +333,71 @@ zstoreInternal cmd dest keys weights aggregate = sendRequest $
 eval
     :: (RedisCtx m f, RedisResult a)
     => ByteString -- ^ script
-    -> [ByteString] -- ^ keys
+    -> [Key] -- ^ keys
     -> [ByteString] -- ^ args
     -> m (f a)
 eval script keys args =
-    sendRequest $ ["EVAL", script, encode numkeys] ++ keys ++ args
+    sendRequest $ ["EVAL", script, encode numkeys] ++ fmap encode keys ++ args
   where
     numkeys = toInteger (length keys)
 
 evalsha
     :: (RedisCtx m f, RedisResult a)
     => ByteString -- ^ script
-    -> [ByteString] -- ^ keys
+    -> [Key] -- ^ keys
     -> [ByteString] -- ^ args
     -> m (f a)
 evalsha script keys args =
-    sendRequest $ ["EVALSHA", script, encode numkeys] ++ keys ++ args
+    sendRequest $ ["EVALSHA", script, encode numkeys] ++ fmap encode keys ++ args
   where
     numkeys = toInteger (length keys)
 
 bitcount
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> m (f Integer)
-bitcount key = sendRequest ["BITCOUNT", key]
+bitcount key = sendRequest ["BITCOUNT", encode key]
 
 bitcountRange
     :: (RedisCtx m f)
-    => ByteString -- ^ key
+    => Key -- ^ key
     -> Integer -- ^ start
     -> Integer -- ^ end
     -> m (f Integer)
 bitcountRange key start end =
-    sendRequest ["BITCOUNT", key, encode start, encode end]
+    sendRequest ["BITCOUNT", encode key, encode start, encode end]
 
 bitopAnd
     :: (RedisCtx m f)
-    => ByteString -- ^ destkey
-    -> [ByteString] -- ^ srckeys
+    => Key -- ^ destkey
+    -> [Key] -- ^ srckeys
     -> m (f Integer)
 bitopAnd dst srcs = bitop "AND" (dst:srcs)
 
 bitopOr
     :: (RedisCtx m f)
-    => ByteString -- ^ destkey
-    -> [ByteString] -- ^ srckeys
+    => Key -- ^ destkey
+    -> [Key] -- ^ srckeys
     -> m (f Integer)
 bitopOr dst srcs = bitop "OR" (dst:srcs)
 
 bitopXor
     :: (RedisCtx m f)
-    => ByteString -- ^ destkey
-    -> [ByteString] -- ^ srckeys
+    => Key -- ^ destkey
+    -> [Key] -- ^ srckeys
     -> m (f Integer)
 bitopXor dst srcs = bitop "XOR" (dst:srcs)
 
 bitopNot
     :: (RedisCtx m f)
-    => ByteString -- ^ destkey
-    -> ByteString -- ^ srckey
+    => Key -- ^ destkey
+    -> Key -- ^ srckey
     -> m (f Integer)
 bitopNot dst src = bitop "NOT" [dst, src]
 
 bitop
     :: (RedisCtx m f)
     => ByteString -- ^ operation
-    -> [ByteString] -- ^ keys
+    -> [Key] -- ^ keys
     -> m (f Integer)
-bitop op ks = sendRequest $ "BITOP" : op : ks
+bitop op ks = sendRequest $ "BITOP" : op : fmap encode ks

--- a/src/Database/Redis/Transactions.hs
+++ b/src/Database/Redis/Transactions.hs
@@ -77,9 +77,9 @@ data TxResult a
 -- |Watch the given keys to determine execution of the MULTI\/EXEC block
 --  (<http://redis.io/commands/watch>).
 watch
-    :: [ByteString] -- ^ key
+    :: [Key] -- ^ key
     -> Redis (Either Reply Status)
-watch key = sendRequest ("WATCH" : key)
+watch key = sendRequest ("WATCH" : fmap encode key)
 
 -- |Forget about all watched keys (<http://redis.io/commands/unwatch>).
 unwatch :: Redis (Either Reply Status)


### PR DESCRIPTION
Hi,
I understand you wanted to keep the library as low level as possible, but would you be willing to consider at least adding some additional type protection through newtypes?

I've tried to change all keys to a newtype:

```
newtype Key = Key { getKey :: ByteString }
  deriving (Eq,Ord,Data,Read,Show,IsString,Monoid)
```

Since this is an instance of `IsString`, all code in tests still works - but at least you cannot freely merge keys and values.

What do you think?
