### PR TITLE
Use Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+# NB: don't set `language: haskell` here
+
+# The following enables several GHC versions to be tested; often it's enough to test only against the last release in a major GHC version. Feel free to omit lines listings versions you don't need/want testing for.
+env:
+ #- CABALVER=1.20 GHCVER=7.6.3
+ - CABALVER=1.20 GHCVER=7.8.4
+ - CABALVER=1.22 GHCVER=7.10.1
+ #- CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
+
+services:
+  - redis-server
+
+# Note: the distinction between `before_install` and `install` is not important.
+before_install:
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - travis_retry cabal update
+ - cabal install --enable-tests
+
+# Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
+script:
+ - cabal configure --enable-tests && cabal build && cabal test --show-details=streaming


### PR DESCRIPTION
This PR adds a .travis.yml file to run CI for Hedis. The file is adapted from [Yesod's version](https://github.com/yesodweb/yesod/blob/master/.travis.yml), which itself is based on https://github.com/hvr/multi-ghc-travis. Here's what the Travis output looks like for me: https://travis-ci.org/MaxGabriel/hedis

It's possible to just use the standard Travis CI Haskell versions, but Travis has a pretty old version of Cabal (1.18) and doesn't have GHC 7.10.

You would still need to enable the hedis repo on travis-ci.org after merging this, if you choose to do so.