### PR TITLE
Blocking calls force their replies evaluation

### DIFF
--- a/codegen/GenCmds.hs
+++ b/codegen/GenCmds.hs
@@ -78,6 +78,10 @@ blacklist = [ manual "AUTH" ["auth"]
                 ["zrevrangebyscore", "zrevrangebyscoreWithscores"
                 ,"zrevrangebyscoreLimit", "zrevrangebyscoreWithscoresLimit"]
             , manual "ZUNIONSTORE" ["zunionstore","zunionstoreWeights"]
+              -- blocking commands force their result to exclude unexpected races
+            , manual "BLPOP" ["blpop"]
+            , manual "BRPOP" ["brpop"]
+            , manual "BRPOPLPUSH" ["brpoplpush"]
             , unimplemented "MONITOR"        -- debugging command
             , unimplemented "SYNC"           -- internal command
             , unimplemented "SHUTDOWN"       -- kills server, throws exception

--- a/src/Database/Redis.hs
+++ b/src/Database/Redis.hs
@@ -103,6 +103,9 @@ module Database.Redis (
     --
     --  Automatic pipelining also works across several calls to 'runRedis', as
     --  long as replies are only evaluated /outside/ the 'runRedis' block.
+    --  Please take a note that as blocking commands could lead to possible
+    --  race conditions between multiple `runRedis` calls they are set to force
+    --  replies evaluation up to those blocking commands.
     --
     --  To keep memory usage low, the number of requests \"in the pipeline\" is
     --  limited (per connection) to 1000. After that number, the next command is

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -290,13 +290,6 @@ rpoplpush
     -> m (f (Maybe ByteString))
 rpoplpush source destination = sendRequest (["RPOPLPUSH"] ++ [encode source] ++ [encode destination] )
 
-brpop
-    :: (RedisCtx m f)
-    => [ByteString] -- ^ key
-    -> Integer -- ^ timeout
-    -> m (f (Maybe (ByteString,ByteString)))
-brpop key timeout = sendRequest (["BRPOP"] ++ map encode key ++ [encode timeout] )
-
 bgrewriteaof
     :: (RedisCtx m f)
     => m (f Status)
@@ -723,14 +716,6 @@ hset
     -> m (f Bool)
 hset key field value = sendRequest (["HSET"] ++ [encode key] ++ [encode field] ++ [encode value] )
 
-brpoplpush
-    :: (RedisCtx m f)
-    => ByteString -- ^ source
-    -> ByteString -- ^ destination
-    -> Integer -- ^ timeout
-    -> m (f (Maybe ByteString))
-brpoplpush source destination timeout = sendRequest (["BRPOPLPUSH"] ++ [encode source] ++ [encode destination] ++ [encode timeout] )
-
 zrevrank
     :: (RedisCtx m f)
     => ByteString -- ^ key
@@ -924,13 +909,6 @@ quit
     :: (RedisCtx m f)
     => m (f Status)
 quit  = sendRequest (["QUIT"] )
-
-blpop
-    :: (RedisCtx m f)
-    => [ByteString] -- ^ key
-    -> Integer -- ^ timeout
-    -> m (f (Maybe (ByteString,ByteString)))
-blpop key timeout = sendRequest (["BLPOP"] ++ map encode key ++ [encode timeout] )
 
 srem
     :: (RedisCtx m f)

--- a/src/Database/Redis/ManualCommands.hs
+++ b/src/Database/Redis/ManualCommands.hs
@@ -401,3 +401,32 @@ bitop
     -> [ByteString] -- ^ keys
     -> m (f Integer)
 bitop op ks = sendRequest $ "BITOP" : op : ks
+
+
+blpop
+    :: (RedisCtx m f)
+    => [ByteString] -- ^ key
+    -> Integer -- ^ timeout
+    -> m (f (Maybe (ByteString,ByteString)))
+blpop key timeout = do
+  r <- sendRequest (["BLPOP"] ++ map encode key ++ [encode timeout] )
+  return $! r
+
+brpop
+    :: (RedisCtx m f)
+    => [ByteString] -- ^ key
+    -> Integer -- ^ timeout
+    -> m (f (Maybe (ByteString,ByteString)))
+brpop key timeout = do
+  r <- sendRequest (["BRPOP"] ++ map encode key ++ [encode timeout] )
+  return $! r
+
+brpoplpush
+    :: (RedisCtx m f)
+    => ByteString -- ^ source
+    -> ByteString -- ^ destination
+    -> Integer -- ^ timeout
+    -> m (f (Maybe ByteString))
+brpoplpush source destination timeout = do
+  r <- sendRequest (["BRPOPLPUSH"] ++ [encode source] ++ [encode destination] ++ [encode timeout] )
+  return $! r


### PR DESCRIPTION
Blocking commands could easily lead to reace conditions
between multiple `runRedis` calls as it is demonstraded in #23.
So to prevent this from happenning those commands are set
to force their replies evaluation up to WHNF