### PR TITLE
Enforce all replies being recieved in runRedis

### DIFF
--- a/src/Database/Redis.hs
+++ b/src/Database/Redis.hs
@@ -101,8 +101,9 @@ module Database.Redis (
     --  Automatic pipelining makes use of Haskell's laziness. As long as a
     --  previous reply is not evaluated, subsequent commands can be pipelined.
     --
-    --  Automatic pipelining also works across several calls to 'runRedis', as
-    --  long as replies are only evaluated /outside/ the 'runRedis' block.
+    --  Automatic pipelining is limited to the scope of 'runRedis' call and
+    --  it is guaranteed that every reply expected as a part of 'runRedis'
+    --  execution gets received after 'runRedis` invocation.
     --
     --  To keep memory usage low, the number of requests \"in the pipeline\" is
     --  limited (per connection) to 1000. After that number, the next command is


### PR DESCRIPTION
Lazy I/O used for automatic pipelining should not leak from runRedis calls. Otherwise it could lead to e.g. conflict with resource pool scope seen in #23 or exceptions being thrown in unexpected places (see e.g. #35)
To prevent this from happening now all replies up to the last should be received inside of `runRedis`.
As a breaking change this should trigger version bump and probably some announcement. 