### PR TITLE
Implement parser without backtracking

### DIFF
--- a/hedis.cabal
+++ b/hedis.cabal
@@ -63,10 +63,11 @@ library
   if flag(dev)
     ghc-prof-options: -auto-all
   exposed-modules:  Database.Redis
-  build-depends:    attoparsec >= 0.12,
+  build-depends:    scanner >= 0.2,
                     base >= 4.6 && < 5,
                     bytestring >= 0.9,
                     bytestring-lexing >= 0.5,
+                    text,
                     deepseq,
                     mtl >= 2,
                     network >= 2,

--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -1,7 +1,8 @@
-resolver: lts-5.3
+resolver: lts-5.1
 packages:
 - '.'
-extra-deps: []
+extra-deps:
+- scanner-0.2
 flags:
   hedis:
     dev: true

--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -3,6 +3,7 @@ packages:
 - '.'
 extra-deps:
 - bytestring-lexing-0.5.0.2
+- scanner-0.2
 flags:
   hedis:
     dev: true

--- a/stack-head.yaml
+++ b/stack-head.yaml
@@ -1,7 +1,8 @@
 resolver: lts-5.3
 packages:
 - '.'
-extra-deps: []
+extra-deps:
+- scanner-0.2
 flags:
   hedis:
     dev: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,8 @@
 resolver: lts-5.3
 packages:
 - '.'
-extra-deps: []
+extra-deps:
+- scanner-0.2
 flags:
   hedis:
     dev: true


### PR DESCRIPTION
This PR is **not ready** for merging.

The existing parser is based on `attoparsec`. But it doesn't use backtracking, so all the bookkeeping that attoparsec does is unnecessary. This RP contains an initial implementation of non-backtracking incremental parser. In my measurements it is 2x faster then attoparsec. In hedis benchmark it shows ~10% performance improvement and noticeable decrease of memory allocations.

The code needs polishing, but before I invest more time, I'd like to know whether you are interested in integrating this into hedis.

Before:

```
ping                  172002.17 Req/s
get                   151622.67 Req/s
mget                  111870.34 Req/s
ping (pipelined)     1020304.05 Req/s
multiExec get 1       102920.15 Req/s
multiExec get 50      623344.24 Req/s
multiExec get 1000    629921.26 Req/s
   5,892,929,256 bytes allocated in the heap
     206,254,696 bytes copied during GC
       5,760,592 bytes maximum residency (45 sample(s))
         724,344 bytes maximum slop
              15 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      7800 colls,     0 par    0.104s   0.198s     0.0000s 0.0003s
  Gen  1        45 colls,     0 par    0.020s   0.026s     0.0006s 0.0021s

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time    1.444s  (  3.308s elapsed)
  GC      time    0.124s  (  0.224s elapsed)
  EXIT    time    0.000s  (  0.000s elapsed)
  Total   time    1.568s  (  3.533s elapsed)

  %GC     time       7.9%  (6.3% elapsed)

  Alloc rate    4,080,975,939 bytes per MUT second

  Productivity  92.1% of total user, 40.9% of total elapsed
```

After:

```
ping                  177501.66 Req/s
get                   176929.46 Req/s
mget                  121375.13 Req/s
ping (pipelined)     1164849.50 Req/s
multiExec get 1       110360.29 Req/s
multiExec get 50      681291.73 Req/s
multiExec get 1000    642743.74 Req/s
   5,454,460,808 bytes allocated in the heap
     181,939,528 bytes copied during GC
       5,642,056 bytes maximum residency (47 sample(s))
         762,456 bytes maximum slop
              14 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      7199 colls,     0 par    0.076s   0.184s     0.0000s 0.0004s
  Gen  1        47 colls,     0 par    0.020s   0.028s     0.0006s 0.0025s

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time    1.424s  (  3.042s elapsed)
  GC      time    0.096s  (  0.212s elapsed)
  EXIT    time    0.000s  (  0.000s elapsed)
  Total   time    1.520s  (  3.255s elapsed)

  %GC     time       6.3%  (6.5% elapsed)

  Alloc rate    3,830,379,780 bytes per MUT second

  Productivity  93.7% of total user, 43.8% of total elapsed
```