### PR TITLE
Export MonadRedis constructors for liftRedis

### DIFF
--- a/src/Database/Redis.hs
+++ b/src/Database/Redis.hs
@@ -131,7 +131,7 @@ module Database.Redis (
     -- * The Redis Monad
     Redis(), runRedis,
     unRedis, reRedis,
-    RedisCtx(), MonadRedis(),
+    RedisCtx(), MonadRedis(..),
 
     -- * Connection
     Connection, connect,


### PR DESCRIPTION
This allows users of this library to extend their own monads with the
`MonadRedis` class.