### PR TITLE
Export all Condition constructors

### DIFF
--- a/codegen/GenCmds.hs
+++ b/codegen/GenCmds.hs
@@ -84,7 +84,7 @@ blacklist = [ manual "AUTH" ["auth"]
             , manual "ZUNIONSTORE" ["zunionstore","zunionstoreWeights"]
             , manualWithType "SET"
                 ["set", "setOpts"]
-                ["Condition", "SetOpts(..)"]
+                ["Condition(..)", "SetOpts(..)"]
             , manualWithType "ZADD"
                 ["zadd", "zaddOpts"]
                 ["ZaddOpts(..)", "defaultZaddOpts"]

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -213,7 +213,7 @@ mget, -- |Get the values of all the given keys (<http://redis.io/commands/mget>)
 mset, -- |Set multiple keys to multiple values (<http://redis.io/commands/mset>). Since Redis 1.0.1
 msetnx, -- |Set multiple keys to multiple values, only if none of the keys exist (<http://redis.io/commands/msetnx>). Since Redis 1.0.1
 psetex, -- |Set the value and expiration in milliseconds of a key (<http://redis.io/commands/psetex>). Since Redis 2.6.0
-Condition,
+Condition(..),
 SetOpts(..),
 set, -- |Set the string value of a key (<http://redis.io/commands/set>). The Redis command @SET@ is split up into 'set', 'setOpts'. Since Redis 1.0.0
 setOpts, -- |Set the string value of a key (<http://redis.io/commands/set>). The Redis command @SET@ is split up into 'set', 'setOpts'. Since Redis 1.0.0


### PR DESCRIPTION
For some reason we were explicitly not exporting constructors for
Condition. This appears to have made it actually impossible to use the
"Opts" variants of set, zadd and specify the conditions.