### PR TITLE
fix syntax errors from redis when using scanOpts to specify match...

### DIFF
--- a/src/Database/Redis/ManualCommands.hs
+++ b/src/Database/Redis/ManualCommands.hs
@@ -699,9 +699,9 @@ addScanOpts
 addScanOpts cmd ScanOpts{..} =
     concat [cmd, match, count]
   where
-    match = maybeToList scanMatch
-    count = map encode $ maybeToList scanCount
-
+    prepend x y = [x, y]
+    match       = maybe [] (prepend "MATCH") scanMatch
+    count       = maybe [] ((prepend "COUNT").encode) scanCount
 
 sscan
     :: (RedisCtx m f)

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -532,12 +532,16 @@ testScans :: Test
 testScans = testCase "scans" $ do
     set "key" "value"       >>=? Ok
     scan cursor0            >>=? (cursor0, ["key"])
+    scanOpts cursor0 sOpts1 >>=? (cursor0, ["key"])
+    scanOpts cursor0 sOpts2 >>=? (cursor0, [])
     sadd "set" ["1"]        >>=? 1
     sscan "set" cursor0     >>=? (cursor0, ["1"])
     hset "hash" "k" "v"     >>=? True
     hscan "hash" cursor0    >>=? (cursor0, [("k", "v")])
     zadd "zset" [(42, "2")] >>=? 1
     zscan "zset" cursor0    >>=? (cursor0, [("2", 42)])
+    where sOpts1 = defaultScanOpts { scanMatch = Just "k*" }
+          sOpts2 = defaultScanOpts { scanMatch = Just "not*"}
 
 testZrangelex ::Test
 testZrangelex = testCase "zrangebylex" $ do


### PR DESCRIPTION
...pattern or count options.

I ran into an issue while using Hedis where Redis will reply with

"ERR syntax error"

Upon use of the (in my case) `Redis.scanOpts` function with a match pattern. The command issued to Redis was:

```
"SCAN" "0" "foo.*"
```
when it should actually be: 

```
"SCAN" "0" "MATCH" "foo.*"
```

This fix addresses this issue.