### PR TITLE
Add GHC 8.2 builds and bumps the LTS versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,10 @@ matrix:
       addons: {apt: {packages: [ghc-7.8.4], sources: [hvr-ghc]}}
     - env: GHCVER=7.10.3 STACK_YAML=stack-7.10.yaml
       addons: {apt: {packages: [ghc-7.10.3],sources: [hvr-ghc]}}
-    - env: GHCVER=8.0.1 STACK_YAML=stack-8.0.yaml
-      addons: {apt: {packages: [ghc-8.0.1],sources: [hvr-ghc]}}
+    - env: GHCVER=8.0.2 STACK_YAML=stack-8.0.yaml
+      addons: {apt: {packages: [ghc-8.0.2],sources: [hvr-ghc]}}
+    - env: GHCVER=8.2.1 STACK_YAML=stack-8.2.yaml
+      addons: {apt: {packages: [ghc-8.2.1],sources: [hvr-ghc]}}
     - env: GHCVER=head STACK_YAML=stack-head.yaml
       addons: {apt: {packages: [cabal-install-head,ghc-head],  sources: [hvr-ghc]}}
 

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2016-05-31
+resolver: lts-8.14
 packages:
 - '.'
 extra-deps:

--- a/stack-8.2.yaml
+++ b/stack-8.2.yaml
@@ -1,8 +1,8 @@
-resolver: lts-6.12
+compiler: ghc-8.2.1
+compiler-check: match-exact
+resolver: lts-8.13
 packages:
 - '.'
-extra-deps:
-- scanner-0.2
 flags:
   hedis:
     dev: true


### PR DESCRIPTION
Updates the LTS version for 7.10 and 8.0.

