### PR TITLE
Added connectTimeout option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog for Hedis
 
+## 0.9.12
+
+* PR #98. Added `connectTimeout` option
+
 ## 0.9.11
 
 * PR #94. Refactor fix for issue #92 - (Connection to Unix sockets is broken)


### PR DESCRIPTION
It's useful at least as a way to differentiate between slow connection establishing and slow execution of required Redis commands (which e.g. could have larger time limits).