### PR TITLE
Return list from srandmemberN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
       addons: {apt: {packages: [cabal-install-head,ghc-head],  sources: [hvr-ghc]}}
 
   allow_failures:
-   - env: GHCVER=head STACK_YAML=stack-head
+   - env: GHCVER=head STACK_YAML=stack-head.yaml
 
 install:
   - stack --no-terminal --skip-ghc-check setup

--- a/src/Database/Redis/ManualCommands.hs
+++ b/src/Database/Redis/ManualCommands.hs
@@ -609,7 +609,7 @@ srandmemberN
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> Integer -- ^ count
-    -> m (f (Maybe ByteString))
+    -> m (f [ByteString])
 srandmemberN key count = sendRequest ["SRANDMEMBER", key, encode count]
 
 

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -8,6 +8,7 @@ import Data.Monoid (mappend)
 import Control.Concurrent
 import Control.Monad
 import Control.Monad.Trans
+import qualified Data.List as L
 import Data.Time
 import Data.Time.Clock.POSIX
 import SlaveThread (fork)
@@ -303,6 +304,9 @@ testSets = testCase "sets" $ do
     spop "set"                  >>=? Just "member"
     srem "set" ["member"]       >>=? 0
     smove "set" "set'" "member" >>=? False
+    _ <- sadd "set" ["member1", "member2"]
+    (fmap L.sort <$> srandmemberN "set" 2) >>=? ["member1", "member2"]
+
 
 testSetAlgebra :: Test
 testSetAlgebra = testCase "set algebra" $ do


### PR DESCRIPTION
`srandmemberN` incorrectly specified its return type as `Maybe
ByteString`, when the point of it is to return a list of items. The
command always returns a multi bulk response even if you specify a
count of 0 or 1 or the key doesn't exist, so there is actually no way
to call this function and not get a `Left`. I have changed that to a
list and added a test to show it works.