### PR TITLE
Add disconnect which destroys all (idle) resources in the pool

### DIFF
--- a/src/Database/Redis.hs
+++ b/src/Database/Redis.hs
@@ -34,6 +34,12 @@ module Database.Redis (
     --      world <- get \"world\"
     --      liftIO $ print (hello,world)
     -- @
+    --
+    -- disconnect all idle resources in the connection pool:
+    --
+    -- @
+    -- 'disconnect' 'conn'
+    -- @
 
     -- ** Command Type Signatures
     -- |Redis commands behave differently when issued in- or outside of a
@@ -156,7 +162,7 @@ module Database.Redis (
     RedisCtx(..), MonadRedis(..),
 
     -- * Connection
-    Connection, ConnectError(..), connect, checkedConnect,
+    Connection, ConnectError(..), connect, checkedConnect, disconnect, 
     ConnectInfo(..), defaultConnectInfo, parseConnectInfo,
     HostName, PortID(..),
     

--- a/src/Database/Redis/Core.hs
+++ b/src/Database/Redis/Core.hs
@@ -3,7 +3,7 @@
     DeriveDataTypeable #-}
 
 module Database.Redis.Core (
-    Connection(..), ConnectError(..), connect, checkedConnect,
+    Connection(..), ConnectError(..), connect, checkedConnect, disconnect, 
     ConnectInfo(..), defaultConnectInfo,
     Redis(), runRedis, unRedis, reRedis,
     RedisCtx(..), MonadRedis(..),
@@ -253,6 +253,10 @@ checkedConnect connInfo = do
     conn <- connect connInfo
     runRedis conn $ void ping
     return conn
+
+-- |Destroy all idle resources in the pool.
+disconnect :: Connection -> IO ()
+disconnect (Conn pool) = destroyAllResources pool
 
 -- The AUTH command. It has to be here because it is used in 'connect'.
 auth


### PR DESCRIPTION
This is the minimal implementation. Basically it closes all handles of idle connection immediately instead of waiting for the `connectMaxIdleTime`.

I'm not sure how I can actually test this as I can't check for the number of connections inside the pool or so...