### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_install:
   - export PATH=~/.local/bin:$PATH
   - curl -L https://github.com/commercialhaskell/stack/releases/download/v1.6.5/stack-1.6.5-linux-x86_64.tar.gz | tar xz -C ~/tmp
   - mv ~/tmp/stack-1.6.5-linux-x86_64/stack ~/.local/bin/
-  - curl -L http://download.redis.io/releases/redis-3.2.11.tar.gz | tar xz -C ~/tmp
-  - cd ~/tmp/redis-3.2.11 && make
-  - ~/tmp/redis-3.2.11/src/redis-server &
+  - curl -L https://github.com/antirez/redis/archive/5.0-rc5.tar.gz | tar xz -C ~/tmp
+  - cd ~/tmp/redis-5.0-rc5 && make
+  - ~/tmp/redis-5.0-rc5/src/redis-server &
   - cd ${TRAVIS_BUILD_DIR}
 
 matrix:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog for Hedis
 
+## 0.10.5
+
+* PR #XXX Fix CI builds with updated Redis version
+
 ## 0.10.4
 
 * PR #112. Implement streams commands


### PR DESCRIPTION
By using the 5.0 release, all the test cases for the streams based commands can pass.