### PR TITLE
Updates for compatibility with Network-2.8.0.0

### DIFF
--- a/src/Database/Redis.hs
+++ b/src/Database/Redis.hs
@@ -164,7 +164,7 @@ module Database.Redis (
     -- * Connection
     Connection, ConnectError(..), connect, checkedConnect, disconnect, 
     ConnectInfo(..), defaultConnectInfo, parseConnectInfo,
-    HostName, PortID(..),
+    HostName, PortNumber,
     
     -- * Commands
     module Database.Redis.Commands,
@@ -195,7 +195,7 @@ import Database.Redis.Core
 import Database.Redis.PubSub
 import Database.Redis.Protocol
 import Database.Redis.ProtocolPipelining
-    (HostName, PortID(..), ConnectionLostException(..))
+    (HostName, PortNumber, ConnectionLostException(..))
 import Database.Redis.Transactions
 import Database.Redis.Types
 import Database.Redis.URL

--- a/src/Database/Redis/Core.hs
+++ b/src/Database/Redis/Core.hs
@@ -23,7 +23,7 @@ import Data.IORef
 import Data.Pool
 import Data.Time
 import Data.Typeable
-import Network
+import qualified Network.Socket as NS
 import Network.TLS (ClientParams)
 
 import Database.Redis.Protocol
@@ -155,8 +155,8 @@ newtype Connection = Conn (Pool PP.Connection)
 -- @
 --
 data ConnectInfo = ConnInfo
-    { connectHost           :: HostName
-    , connectPort           :: PortID
+    { connectHost           :: NS.HostName
+    , connectPort           :: NS.PortNumber
     , connectAuth           :: Maybe B.ByteString
     -- ^ When the server is protected by a password, set 'connectAuth' to 'Just'
     --   the password. Each connection will then authenticate by the 'auth'
@@ -201,7 +201,7 @@ instance Exception ConnectError
 defaultConnectInfo :: ConnectInfo
 defaultConnectInfo = ConnInfo
     { connectHost           = "localhost"
-    , connectPort           = PortNumber 6379
+    , connectPort           = 6379
     , connectAuth           = Nothing
     , connectDatabase       = 0
     , connectMaxConnections = 50

--- a/src/Database/Redis/ProtocolPipelining.hs
+++ b/src/Database/Redis/ProtocolPipelining.hs
@@ -17,7 +17,7 @@ module Database.Redis.ProtocolPipelining (
   Connection,
   connect, enableTLS, beginReceiving, disconnect, request, send, recv, flush,
   ConnectionLostException(..),
-  HostName, PortID(..)
+  HostName, PortNumber
 ) where
 
 import           Prelude
@@ -31,8 +31,6 @@ import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
 import           Data.IORef
 import           Data.Typeable
-import           Network
-import qualified Network.BSD as BSD
 import qualified Network.Socket as NS
 import qualified Network.TLS as TLS
 import           System.IO
@@ -40,6 +38,9 @@ import           System.IO.Error
 import           System.IO.Unsafe
 
 import           Database.Redis.Protocol
+
+type HostName = NS.HostName
+type PortNumber = NS.PortNumber
 
 data ConnectionContext = NormalHandle Handle | TLSContext TLS.Context
 
@@ -71,8 +72,30 @@ data ConnectTimeout = ConnectTimeout ConnectPhase
 
 instance Exception ConnectTimeout
 
-connect :: HostName -> PortID -> Maybe Int -> IO Connection
-connect hostName portID timeoutOpt =
+getHostAddrInfo :: NS.HostName -> NS.PortNumber -> IO [NS.AddrInfo]
+getHostAddrInfo hostname port = do
+  addresses <- NS.getAddrInfo
+    (Just NS.defaultHints)
+    (Just hostname)
+    (Just (show port))
+  return addresses
+
+connectSocket :: [NS.AddrInfo] -> IO NS.Socket
+connectSocket addresses = do
+  let addrInfo = head addresses
+  socket <- NS.socket (NS.addrFamily addrInfo) NS.Stream NS.defaultProtocol
+  catch
+    (do
+      _ <- NS.connect socket (NS.addrAddress addrInfo)
+      return socket)
+    (\(SomeException e) -> do
+      _ <- NS.close socket
+      case (tail addresses) of
+        [] -> throwIO e
+        others -> connectSocket others)
+
+connect :: NS.HostName -> NS.PortNumber -> Maybe Int -> IO Connection
+connect hostName portNumber timeoutOpt =
   bracketOnError hConnect hClose $ \h -> do
     hSetBinaryMode h True
     connReplies <- newIORef []
@@ -83,7 +106,7 @@ connect hostName portID timeoutOpt =
   where
         hConnect = do
           phaseMVar <- newMVar PhaseUnknown
-          let doConnect = hConnect' portID phaseMVar
+          let doConnect = hConnect' phaseMVar
           case timeoutOpt of
             Nothing -> doConnect
             Just micros -> do
@@ -93,16 +116,14 @@ connect hostName portID timeoutOpt =
                 Right () -> do
                   phase <- readMVar phaseMVar
                   errConnectTimeout phase
-        hConnect' (PortNumber port) mvar =
-          bracketOnError mkSocket NS.close $ \sock -> do
+        hConnect' mvar =
+          do
+            addrInfo <- getHostAddrInfo hostName portNumber
+            sock <- connectSocket addrInfo
             NS.setSocketOption sock NS.KeepAlive 1
             void $ swapMVar mvar PhaseResolve
-            host <- BSD.getHostByName hostName
             void $ swapMVar mvar PhaseOpenSocket
-            NS.connect sock $ NS.SockAddrInet port (BSD.hostAddress host)
             NS.socketToHandle sock ReadWriteMode
-        hConnect' _ _ = connectTo hostName portID
-        mkSocket   = NS.socket NS.AF_INET NS.Stream 0
 
 enableTLS :: TLS.ClientParams -> Connection -> IO Connection
 enableTLS tlsParams conn@Conn{..} = do

--- a/src/Database/Redis/URL.hs
+++ b/src/Database/Redis/URL.hs
@@ -10,7 +10,6 @@ import Control.Error.Util (note)
 import Control.Monad (guard)
 import Data.Monoid ((<>))
 import Database.Redis.Core (ConnectInfo(..), defaultConnectInfo)
-import Database.Redis.ProtocolPipelining (PortID(..))
 import Network.HTTP.Base
 import Network.URI (parseURI, uriPath, uriScheme)
 import Text.Read (readMaybe)
@@ -22,7 +21,7 @@ import qualified Data.ByteString.Char8 as C8
 -- Username is ignored, path is used to specify the database:
 --
 -- >>> parseConnectInfo "redis://username:password@host:42/2"
--- Right (ConnInfo {connectHost = "host", connectPort = PortNumber 42, connectAuth = Just "password", connectDatabase = 2, connectMaxConnections = 50, connectMaxIdleTime = 30s, connectTimeout = Nothing, connectTLSParams = Nothing})
+-- Right (ConnInfo {connectHost = "host", connectPort = 42, connectAuth = Just "password", connectDatabase = 2, connectMaxConnections = 50, connectMaxIdleTime = 30s, connectTimeout = Nothing, connectTLSParams = Nothing})
 --
 -- >>> parseConnectInfo "redis://username:password@host:42/db"
 -- Left "Invalid port: db"
@@ -36,7 +35,7 @@ import qualified Data.ByteString.Char8 as C8
 -- @'defaultConnectInfo'@:
 --
 -- >>> parseConnectInfo "redis://"
--- Right (ConnInfo {connectHost = "localhost", connectPort = PortNumber 6379, connectAuth = Nothing, connectDatabase = 0, connectMaxConnections = 50, connectMaxIdleTime = 30s, connectTimeout = Nothing, connectTLSParams = Nothing})
+-- Right (ConnInfo {connectHost = "localhost", connectPort = 6379, connectAuth = Nothing, connectDatabase = 0, connectMaxConnections = 50, connectMaxIdleTime = 30s, connectTimeout = Nothing, connectTLSParams = Nothing})
 --
 parseConnectInfo :: String -> Either String ConnectInfo
 parseConnectInfo url = do
@@ -57,8 +56,7 @@ parseConnectInfo url = do
         { connectHost = if null h
             then connectHost defaultConnectInfo
             else h
-        , connectPort = maybe (connectPort defaultConnectInfo)
-            (PortNumber . fromIntegral) $ port uriAuth
+        , connectPort = maybe (connectPort defaultConnectInfo) fromIntegral (port uriAuth)
         , connectAuth = C8.pack <$> password uriAuth
         , connectDatabase = db
         }

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.2
+resolver: lts-12.5
 packages:
 - '.'
 extra-deps:


### PR DESCRIPTION
With these changes, the `connect` function will try to connect to all the candidate IP addresses for a given domain name until either it successfully connects one of them or fails to connect to all of them.

`PortID` used to be exposed in multiple places but got deprecated with the version 2.8.0.0 of `Network`. These changes replace `PortID` with the new `PortNumber` and therefore should probably be considered as breaking changes.

I made a new `stack-8.4.3.yaml` file and updated `stack.yaml` with a new version of the resolver but I'm not sure if this is the "correct way" to do it. Please let me know it should be done differently.

When running the tests for these changes, two of them failed; however, those also fail on the master branch on my computer. Can some one make sure all the tests successfully pass both on the master branch and with these changes?

By the way, Haskell beginner here, so please forgive me if I'm doing anything stupid 😅

Fixes https://github.com/informatikr/hedis/issues/114
See also https://github.com/informatikr/hedis/pull/125