### PR TITLE
Bring back ability to connect via a Unix Socket

### DIFF
--- a/hedis.cabal
+++ b/hedis.cabal
@@ -1,5 +1,5 @@
 name:               hedis
-version:            0.11.1
+version:            0.12.0
 synopsis:
     Client library for the Redis datastore: supports full command set,
     pipelining.

--- a/src/Database/Redis.hs
+++ b/src/Database/Redis.hs
@@ -162,10 +162,10 @@ module Database.Redis (
     RedisCtx(..), MonadRedis(..),
 
     -- * Connection
-    Connection, ConnectError(..), connect, checkedConnect, disconnect, 
+    Connection, ConnectError(..), connect, checkedConnect, disconnect,
     ConnectInfo(..), defaultConnectInfo, parseConnectInfo,
-    HostName, PortNumber,
-    
+    PortID(..),
+
     -- * Commands
     module Database.Redis.Commands,
     
@@ -195,7 +195,7 @@ import Database.Redis.Core
 import Database.Redis.PubSub
 import Database.Redis.Protocol
 import Database.Redis.ProtocolPipelining
-    (HostName, PortNumber, ConnectionLostException(..))
+    (PortID(..), ConnectionLostException(..))
 import Database.Redis.Transactions
 import Database.Redis.Types
 import Database.Redis.URL

--- a/src/Database/Redis/Core.hs
+++ b/src/Database/Redis/Core.hs
@@ -156,7 +156,7 @@ newtype Connection = Conn (Pool PP.Connection)
 --
 data ConnectInfo = ConnInfo
     { connectHost           :: NS.HostName
-    , connectPort           :: NS.PortNumber
+    , connectPort           :: PP.PortID
     , connectAuth           :: Maybe B.ByteString
     -- ^ When the server is protected by a password, set 'connectAuth' to 'Just'
     --   the password. Each connection will then authenticate by the 'auth'
@@ -201,7 +201,7 @@ instance Exception ConnectError
 defaultConnectInfo :: ConnectInfo
 defaultConnectInfo = ConnInfo
     { connectHost           = "localhost"
-    , connectPort           = 6379
+    , connectPort           = PP.PortNumber 6379
     , connectAuth           = Nothing
     , connectDatabase       = 0
     , connectMaxConnections = 50


### PR DESCRIPTION
ConnectInfo.connectPort now uses PortID product type again