### PR TITLE
Fix some asynchronous exception safety problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-
+/dist-newstyle/
 /redis/
 /dist/
 /cabal-dev/
+/.ghc.environment.*
 dump.rdb
 appendonly.aof
 *.prof


### PR DESCRIPTION
In #126, the use of `bracketOnError` in `hConnect'` was replaced with a  `catch` in `connectSocket`. Unfortunately, that `catch` comes after the call to `NS.socket`, so if an asynchronous exception happens after the call to `NS.socket`, but before entering the `catch` block, `NS.close` won't be called and the socket handle will leak. 

This PR fixes the problem, plus as a bonus there's also a small improvement to `getHostAddrInfo`. 

We had a problem in production after upgrading to `hedis-0.11` that was fixed by downgrading to `0.10`. We're still investigating it, but highly suspect that it was caused by the change in #126.

/cc @k-bx @arybczak