### PR TITLE
Added support of +/- inf redis argument

### DIFF
--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -260,6 +260,7 @@ XInfoStreamResponse(..),
 xinfoStream, -- |Get info about a stream. The Redis command @XINFO@ is split into 'xinfoConsumers', 'xinfoGroups', and 'xinfoStream'. Since Redis 5.0.0
 xdel, -- |Delete messages from a stream. Since Redis 5.0.0
 xtrim, -- |Set the upper bound for number of messages in a stream. Since Redis 5.0.0
+inf, -- |Constructor for `inf` Redis argument values
 
 -- * Unimplemented Commands
 -- |These commands are not implemented, as of now. Library

--- a/src/Database/Redis/ManualCommands.hs
+++ b/src/Database/Redis/ManualCommands.hs
@@ -1194,3 +1194,6 @@ xtrim stream opts = sendRequest $ ["XTRIM", stream] ++ optArgs
             NoArgs -> []
             Maxlen max -> ["MAXLEN", encode max]
             ApproxMaxlen max -> ["MAXLEN", "~", encode max]
+
+inf :: RealFloat a => a
+inf = 1 / 0

--- a/src/Database/Redis/Types.hs
+++ b/src/Database/Redis/Types.hs
@@ -39,7 +39,10 @@ instance RedisArg Integer where
     encode = pack . show
 
 instance RedisArg Double where
-    encode = pack . show
+    encode a
+        | isInfinite a && a > 0 = "+inf"
+        | isInfinite a && a < 0 = "-inf"
+        | otherwise = pack . show $ a
 
 ------------------------------------------------------------------------------
 -- RedisResult instances

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -357,6 +357,7 @@ testZSets = testCase "sorted sets" $ do
     zrevrangeWithscores "key" 0 1                     >>=? [("v3",42),("v2",2)]
     zrangebyscore "key" 0.5 1.5                       >>=? ["v1"]
     zrangebyscoreWithscores "key" 0.5 1.5             >>=? [("v1",1)]
+    zrangebyscoreWithscores "key" (-inf) inf          >>=? [("v1",1.0),("v2",2.0),("v3",42.0)]
     zrangebyscoreLimit "key" 0.5 2.5 0 1              >>=? ["v1"]
     zrangebyscoreWithscoresLimit "key" 0.5 2.5 0 1    >>=? [("v1",1)]
     zrevrangebyscore "key" 1.5 0.5                    >>=? ["v1"]


### PR DESCRIPTION
Hi! Thanks for this useful library!

I had some issues with Redis `inf` arguments and found this [issue](https://github.com/informatikr/hedis/issues/119).
In this PR I implemented handling of infinity values for `Double` arguments, as it was discussed in issue.

Also, doubting i decided to add `inf` value constructor.

Tests are green, including new test for `zrange` API.

Any feedback welcome!