### PR TITLE
WIP: Clustering Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Main.hs
 .stack-work
 TAGS
 stack.yaml.lock
+.nvimrc

--- a/hedis.cabal
+++ b/hedis.cabal
@@ -69,10 +69,12 @@ library
   exposed-modules:  Database.Redis
   build-depends:    scanner >= 0.2,
                     async >= 2.1,
+                    array >= 0.5.3,
                     base >= 4.8 && < 5,
                     bytestring >= 0.9,
                     bytestring-lexing >= 0.5,
                     unordered-containers,
+                    containers,
                     text,
                     deepseq,
                     mtl >= 2,
@@ -84,12 +86,16 @@ library
                     vector >= 0.9,
                     HTTP,
                     errors,
-                    network-uri
+                    network-uri,
+                    crc16 == 0.1.0
   if !impl(ghc >= 8.0)
     build-depends:
       semigroups >= 0.11 && < 0.19
 
   other-modules:    Database.Redis.Core,
+                    Database.Redis.Connection,
+                    Database.Redis.Cluster,
+                    Database.Redis.Cluster.HashSlot,
                     Database.Redis.ProtocolPipelining,
                     Database.Redis.Protocol,
                     Database.Redis.PubSub,
@@ -97,7 +103,8 @@ library
                     Database.Redis.Types
                     Database.Redis.Commands,
                     Database.Redis.ManualCommands,
-                    Database.Redis.URL
+                    Database.Redis.URL,
+                    Database.Redis.ConnectionContext
 
 benchmark hedis-benchmark
     type: exitcode-stdio-1.0

--- a/hedis.cabal
+++ b/hedis.cabal
@@ -87,7 +87,8 @@ library
                     HTTP,
                     errors,
                     network-uri,
-                    crc16 == 0.1.0
+                    crc16 == 0.1.0,
+                    say 
   if !impl(ghc >= 8.0)
     build-depends:
       semigroups >= 0.11 && < 0.19

--- a/hedis.cabal
+++ b/hedis.cabal
@@ -97,6 +97,7 @@ library
                     Database.Redis.Connection,
                     Database.Redis.Cluster,
                     Database.Redis.Cluster.HashSlot,
+                    Database.Redis.Cluster.Command,
                     Database.Redis.ProtocolPipelining,
                     Database.Redis.Protocol,
                     Database.Redis.PubSub,

--- a/hedis.cabal
+++ b/hedis.cabal
@@ -1,5 +1,5 @@
 name:               hedis
-version:            0.12.8
+version:            0.12.8.1
 synopsis:
     Client library for the Redis datastore: supports full command set,
     pipelining.
@@ -87,7 +87,6 @@ library
                     HTTP,
                     errors,
                     network-uri,
-                    crc16 == 0.1.0,
                     say 
   if !impl(ghc >= 8.0)
     build-depends:

--- a/src/Database/Redis.hs
+++ b/src/Database/Redis.hs
@@ -163,7 +163,7 @@ module Database.Redis (
 
     -- * Connection
     Connection, ConnectError(..), connect, checkedConnect, disconnect,
-    ConnectInfo(..), defaultConnectInfo, parseConnectInfo,
+    ConnectInfo(..), defaultConnectInfo, parseConnectInfo, connectCluster,
     PortID(..),
 
     -- * Commands
@@ -189,15 +189,26 @@ module Database.Redis (
     --
     --  > lindex :: ByteString -> Integer -> Redis (Either Reply ByteString)
     --
+    HashSlot, keyToSlot
 ) where
 
 import Database.Redis.Core
+import Database.Redis.Connection
+    ( runRedis
+    , connectCluster
+    , defaultConnectInfo
+    , ConnectInfo(..)
+    , disconnect
+    , checkedConnect
+    , connect
+    , ConnectError(..)
+    , Connection(..))
+import Database.Redis.ConnectionContext(PortID(..), ConnectionLostException(..))
 import Database.Redis.PubSub
 import Database.Redis.Protocol
-import Database.Redis.ProtocolPipelining
-    (PortID(..), ConnectionLostException(..))
 import Database.Redis.Transactions
 import Database.Redis.Types
 import Database.Redis.URL
 
 import Database.Redis.Commands
+import Database.Redis.Cluster.HashSlot(HashSlot, keyToSlot)

--- a/src/Database/Redis/Cluster.hs
+++ b/src/Database/Redis/Cluster.hs
@@ -1,16 +1,19 @@
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
 module Database.Redis.Cluster
   ( Connection(..)
   , NodeRole(..)
+  , NodeConnection(..)
   , Node(..)
   , ShardMap(..)
   , HashSlot
   , Shard(..)
   , connect
-  , request
+  , disconnect
+  --, request
+  , requestPipelined
   , nodes
 ) where
 
@@ -18,30 +21,42 @@ import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as Char8
 import qualified Data.IORef as IOR
 import Data.Maybe(listToMaybe)
-import Control.Exception(Exception, throwIO)
+import Data.List(nub, sortBy)
+import Data.Map(fromListWith, assocs)
+import Data.Function(on)
+import Control.Exception(Exception, throwIO, BlockedIndefinitelyOnMVar(..), catches, Handler(..))
+import Control.Concurrent.MVar(MVar, newMVar, readMVar, modifyMVar, modifyMVar_)
+import Control.Monad(zipWithM, when)
 import Database.Redis.Cluster.HashSlot(HashSlot, keyToSlot)
 import qualified Database.Redis.ConnectionContext as CC
+import qualified Data.HashMap.Strict as HM
 import qualified Data.IntMap.Strict as IntMap
 import           Data.Typeable
-import qualified Network.Socket as NS
 import qualified Scanner
+import System.IO.Unsafe(unsafeInterleaveIO)
+import Say(sayString)
 
 import Database.Redis.Protocol(Reply(Error), renderRequest, reply)
 
 
-data Connection = Connection
-    { ctx :: CC.ConnectionContext
-    , lastRecvRef :: IOR.IORef (Maybe B.ByteString) }
+data NodeConnection = NodeConnection CC.ConnectionContext (IOR.IORef (Maybe B.ByteString)) NodeID
 
-instance Show Connection where
-    show Connection{..} = "Connection{ ctx = " <> show ctx <> ", lastRecvRef = IORef}"
+instance Eq NodeConnection where
+    (NodeConnection _ _ id1) == (NodeConnection _ _ id2) = id1 == id2
 
-data NodeRole = Master | Slave deriving (Show)
+instance Ord NodeConnection where
+    compare (NodeConnection _ _ id1) (NodeConnection _ _ id2) = compare id1 id2
+
+data PipelineState = Pending [[B.ByteString]] | Evaluated [Reply]
+newtype Pipeline = Pipeline (MVar PipelineState)
+data Connection = Connection (HM.HashMap NodeID NodeConnection) (MVar Pipeline)
+
+data NodeRole = Master | Slave deriving (Show, Eq, Ord)
 
 type Host = String
 type Port = Int
 type NodeID = B.ByteString
-data Node = Node NodeID NodeRole Connection Host Port deriving (Show)
+data Node = Node NodeID NodeRole Host Port deriving (Show, Eq, Ord)
 
 type MasterNode = Node
 type SlaveNode = Node
@@ -53,37 +68,101 @@ newtype MissingNodeException = MissingNodeException [B.ByteString] deriving (Sho
 
 instance Exception MissingNodeException
 
-connect :: NS.HostName -> NS.PortNumber -> Maybe Int -> IO Connection
-connect hostName portNumber timeoutOpt = do
-    ctx <- CC.connect hostName (CC.PortNumber portNumber) timeoutOpt
-    lastRecvRef <- IOR.newIORef Nothing
-    return Connection{..}
+
+connect :: ShardMap -> Maybe Int -> IO Connection
+connect shardMap timeoutOpt = do
+        stateVar <- newMVar $ Pending []
+        pipelineVar <- newMVar $ Pipeline stateVar
+        nodeConns <- nodeConnections
+        return $ Connection nodeConns pipelineVar where
+    nodeConnections :: IO (HM.HashMap NodeID NodeConnection)
+    nodeConnections = HM.fromList <$> mapM connectNode (nub $ nodes shardMap)
+    connectNode :: Node -> IO (NodeID, NodeConnection)
+    connectNode (Node n _ host port) = do
+        ctx <- CC.connect host (CC.PortNumber $ toEnum port) timeoutOpt
+        ref <- IOR.newIORef Nothing
+        return (n, NodeConnection ctx ref n)
+
+disconnect :: Connection -> IO ()
+disconnect (Connection nodeConnMap _) = mapM_ disconnectNode (HM.elems nodeConnMap) where
+    disconnectNode (NodeConnection nodeCtx _ _) = CC.disconnect nodeCtx
 
 
-request :: IOR.IORef ShardMap -> (() -> IO ShardMap) -> [B.ByteString] -> IO Reply
-request shardMapRef refreshShardMap requestData = do
-    shardMap <- IOR.readIORef shardMapRef
-    let maybeNode = nodeForCommand shardMap requestData
-    case maybeNode of
-        Nothing -> throwIO $ MissingNodeException requestData
-        Just node -> do
-            resp <- requestNode node (renderRequest requestData)
-            case resp of
-                (Error errString) | B.isPrefixOf "MOVED" errString -> do
-                    newShardMap <- refreshShardMap ()
-                    IOR.writeIORef shardMapRef newShardMap
-                    request shardMapRef refreshShardMap requestData
-                (askingRedirection -> Just (host, port)) -> do
-                    let maybeAskNode = nodeWithHostAndPort shardMap host port
-                    case maybeAskNode of
-                        Just askNode -> do
-                            _ <- requestNode askNode (renderRequest ["ASKING"])
-                            requestNode askNode (renderRequest requestData)
-                        Nothing -> do
-                            newShardMap <- refreshShardMap ()
-                            IOR.writeIORef shardMapRef newShardMap
-                            request shardMapRef refreshShardMap requestData
-                _ -> return resp
+requestPipelined :: MVar ShardMap -> IO ShardMap -> Connection -> [B.ByteString] -> IO Reply
+requestPipelined shardMapVar refreshAction conn@(Connection _ pipelineVar) nextRequest = modifyMVar pipelineVar $ \(Pipeline stateVar) -> do
+    (newStateVar, repliesIndex) <- hasLocked "locked adding to pipeline" $ modifyMVar stateVar $ \case
+        Pending requests -> return (Pending (nextRequest:requests), (stateVar, length requests))
+        e@(Evaluated _) -> do
+            s' <- newMVar $ Pending [nextRequest]
+            return (e, (s', 0))
+    evaluateAction <- unsafeInterleaveIO $ do
+        replies <- hasLocked "locked evaluating replies" $ modifyMVar newStateVar $ \case
+            Evaluated replies -> return (Evaluated replies, replies)
+            Pending requests-> do
+                replies <- evaluatePipeline shardMapVar refreshAction conn requests
+                return (Evaluated replies, replies)
+        return $ replies !! repliesIndex
+    return (Pipeline newStateVar, evaluateAction)
+
+
+
+data PendingRequest = PendingRequest Int [B.ByteString]
+data CompletedRequest = CompletedRequest Int [B.ByteString] Reply
+
+rawRequest :: PendingRequest -> [B.ByteString]
+rawRequest (PendingRequest _ r) =  r
+
+responseIndex :: CompletedRequest -> Int
+responseIndex (CompletedRequest i _ _) = i
+
+rawResponse :: CompletedRequest -> Reply
+rawResponse (CompletedRequest _ _ r) = r
+
+requestForResponse :: CompletedRequest -> [B.ByteString]
+requestForResponse (CompletedRequest _ r _) = r
+
+evaluatePipeline :: MVar ShardMap -> IO ShardMap -> Connection -> [[B.ByteString]] -> IO [Reply]
+evaluatePipeline shardMapVar refreshShardmapAction conn requests = do
+        shardMap <- hasLocked "reading shardmap in evaluatePipeline" $ readMVar shardMapVar
+        requestsByNode <- getRequestsByNode shardMap
+        resps <- concat <$> mapM (uncurry executeRequests) requestsByNode
+        _ <- when (any (moved . rawResponse) resps) (refreshShardMapVar "locked refreshing due to moved responses")
+        retriedResps <- mapM (retry 0) resps
+        return $ map rawResponse $ sortBy (on compare responseIndex) retriedResps where
+    getRequestsByNode :: ShardMap -> IO [(NodeConnection, [PendingRequest])]
+    getRequestsByNode shardMap = do
+        commandsWithNodes <- zipWithM (requestWithNode shardMap) [0..] (reverse requests)
+        return $ assocs $ fromListWith (++) commandsWithNodes
+    requestWithNode :: ShardMap -> Int -> [B.ByteString] -> IO (NodeConnection, [PendingRequest])
+    requestWithNode shardMap index request = do
+        nodeConn <- nodeConnectionForCommandOrThrow shardMap conn request
+        return (nodeConn, [PendingRequest index request])
+    executeRequests :: NodeConnection -> [PendingRequest] -> IO [CompletedRequest]
+    executeRequests nodeConn nodeRequests = do
+        replies <- requestNode nodeConn $ map rawRequest nodeRequests
+        return $ map (\(PendingRequest i r, rep) -> CompletedRequest i r rep) (zip nodeRequests replies)
+    retry :: Int -> CompletedRequest -> IO CompletedRequest
+    retry retryCount resp@(CompletedRequest index request thisReply) = do
+        retryReply <- case thisReply of
+            (Error errString) | B.isPrefixOf "MOVED" errString -> do
+                shardMap <- hasLocked "reading shard map in retry MOVED" $ readMVar shardMapVar
+                nodeConn <- nodeConnectionForCommandOrThrow shardMap conn (requestForResponse resp)
+                head <$> requestNode nodeConn [request]
+            (askingRedirection -> Just (host, port)) -> do
+                shardMap <- hasLocked "reading shardmap in retry ASK" $ readMVar shardMapVar
+                let maybeAskNode = nodeConnWithHostAndPort shardMap conn host port
+                case maybeAskNode of
+                    Just askNode -> last <$> requestNode askNode [["ASKING"], requestForResponse resp]
+                    Nothing -> case retryCount of
+                        0 -> do
+                            _ <- refreshShardMapVar "missing node in first retry of ASK"
+                            rawResponse <$> retry (retryCount + 1) resp
+                        _ -> throwIO $ MissingNodeException (requestForResponse resp)
+            _ -> return thisReply
+        return (CompletedRequest index request retryReply)
+    refreshShardMapVar :: String -> IO ()
+    refreshShardMapVar msg = hasLocked msg $ modifyMVar_ shardMapVar (const refreshShardmapAction)
+
 
 askingRedirection :: Reply -> Maybe (Host, Port)
 askingRedirection (Error errString) = case Char8.words errString of
@@ -95,6 +174,23 @@ askingRedirection (Error errString) = case Char8.words errString of
     _ -> Nothing
 askingRedirection _ = Nothing
 
+moved :: Reply -> Bool
+moved (Error errString) = case Char8.words errString of
+    "MOVED":_ -> True
+    _ -> False
+moved _ = False
+
+
+nodeConnWithHostAndPort :: ShardMap -> Connection -> Host -> Port -> Maybe NodeConnection
+nodeConnWithHostAndPort shardMap (Connection nodeConns _) host port = do
+    node <- nodeWithHostAndPort shardMap host port
+    HM.lookup (nodeId node) nodeConns
+
+nodeConnectionForCommandOrThrow :: ShardMap -> Connection -> [B.ByteString] -> IO NodeConnection
+nodeConnectionForCommandOrThrow shardMap (Connection nodeConns _) command = maybe (throwIO $ MissingNodeException command) return maybeNode where
+    maybeNode = do
+        node <- nodeForCommand shardMap command
+        HM.lookup (nodeId node) nodeConns
 
 nodeForCommand :: ShardMap -> [B.ByteString] -> Maybe Node
 nodeForCommand (ShardMap shards) (_:key:_) = do
@@ -102,21 +198,30 @@ nodeForCommand (ShardMap shards) (_:key:_) = do
     Just master
 nodeForCommand _ _ = Nothing
 
-requestNode :: Node -> B.ByteString -> IO Reply
-requestNode (Node _ _ Connection{..} _ _) requestData = do
-    _ <- CC.send ctx requestData >> CC.flush ctx
-    maybeLastRecv <- IOR.readIORef lastRecvRef
-    scanResult <- case maybeLastRecv of
-        Just lastRecv -> Scanner.scanWith (CC.recv ctx) reply lastRecv
-        Nothing -> Scanner.scanWith (CC.recv ctx) reply B.empty
 
+requestNode :: NodeConnection -> [[B.ByteString]] -> IO [Reply]
+requestNode (NodeConnection ctx lastRecvRef _) requests = do
+    _ <- mapM_ (sendNode . renderRequest) requests
+    _ <- CC.flush ctx
+    sequence $ take (length requests) (repeat recvNode)
 
-    case scanResult of
-      Scanner.Fail{}       -> CC.errConnClosed
-      Scanner.More{}    -> error "Hedis: parseWith returned Partial"
-      Scanner.Done rest' r -> do
-        IOR.writeIORef lastRecvRef (Just rest')
-        return r
+    where
+
+    sendNode :: B.ByteString -> IO ()
+    sendNode = CC.send ctx
+    recvNode :: IO Reply
+    recvNode = do
+        maybeLastRecv <- IOR.readIORef lastRecvRef
+        scanResult <- case maybeLastRecv of
+            Just lastRecv -> Scanner.scanWith (CC.recv ctx) reply lastRecv
+            Nothing -> Scanner.scanWith (CC.recv ctx) reply B.empty
+
+        case scanResult of
+          Scanner.Fail{}       -> CC.errConnClosed
+          Scanner.More{}    -> error "Hedis: parseWith returned Partial"
+          Scanner.Done rest' r -> do
+            IOR.writeIORef lastRecvRef (Just rest')
+            return r
 
 nodes :: ShardMap -> [Node]
 nodes (ShardMap shardMap) = concatMap snd $ IntMap.toList $ fmap shardNodes shardMap where
@@ -125,4 +230,13 @@ nodes (ShardMap shardMap) = concatMap snd $ IntMap.toList $ fmap shardNodes shar
 
 
 nodeWithHostAndPort :: ShardMap -> Host -> Port -> Maybe Node
-nodeWithHostAndPort shardMap host port = listToMaybe $ filter (\(Node _ _ _ nodeHost nodePort) -> port == nodePort && host == nodeHost) $ nodes shardMap
+nodeWithHostAndPort shardMap host port = listToMaybe $ filter (\(Node _ _ nodeHost nodePort) -> port == nodePort && host == nodeHost) $ nodes shardMap
+
+nodeId :: Node -> NodeID
+nodeId (Node theId _ _ _) = theId
+
+hasLocked :: String -> IO a -> IO a
+hasLocked msg action =
+  action `catches`
+  [ Handler $ \exc@BlockedIndefinitelyOnMVar -> sayString ("[MVar]: " ++ msg) >> throwIO exc
+  ]

--- a/src/Database/Redis/Cluster.hs
+++ b/src/Database/Redis/Cluster.hs
@@ -1,0 +1,128 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns #-}
+module Database.Redis.Cluster
+  ( Connection(..)
+  , NodeRole(..)
+  , Node(..)
+  , ShardMap(..)
+  , HashSlot
+  , Shard(..)
+  , connect
+  , request
+  , nodes
+) where
+
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as Char8
+import qualified Data.IORef as IOR
+import Data.Maybe(listToMaybe)
+import Control.Exception(Exception, throwIO)
+import Database.Redis.Cluster.HashSlot(HashSlot, keyToSlot)
+import qualified Database.Redis.ConnectionContext as CC
+import qualified Data.IntMap.Strict as IntMap
+import           Data.Typeable
+import qualified Network.Socket as NS
+import qualified Scanner
+
+import Database.Redis.Protocol(Reply(Error), renderRequest, reply)
+
+
+data Connection = Connection
+    { ctx :: CC.ConnectionContext
+    , lastRecvRef :: IOR.IORef (Maybe B.ByteString) }
+
+instance Show Connection where
+    show Connection{..} = "Connection{ ctx = " <> show ctx <> ", lastRecvRef = IORef}"
+
+data NodeRole = Master | Slave deriving (Show)
+
+type Host = String
+type Port = Int
+type NodeID = B.ByteString
+data Node = Node NodeID NodeRole Connection Host Port deriving (Show)
+
+type MasterNode = Node
+type SlaveNode = Node
+data Shard = Shard MasterNode [SlaveNode] deriving Show
+
+newtype ShardMap = ShardMap (IntMap.IntMap Shard) deriving (Show)
+
+newtype MissingNodeException = MissingNodeException [B.ByteString] deriving (Show, Typeable)
+
+instance Exception MissingNodeException
+
+connect :: NS.HostName -> NS.PortNumber -> Maybe Int -> IO Connection
+connect hostName portNumber timeoutOpt = do
+    ctx <- CC.connect hostName (CC.PortNumber portNumber) timeoutOpt
+    lastRecvRef <- IOR.newIORef Nothing
+    return Connection{..}
+
+
+request :: IOR.IORef ShardMap -> (() -> IO ShardMap) -> [B.ByteString] -> IO Reply
+request shardMapRef refreshShardMap requestData = do
+    shardMap <- IOR.readIORef shardMapRef
+    let maybeNode = nodeForCommand shardMap requestData
+    case maybeNode of
+        Nothing -> throwIO $ MissingNodeException requestData
+        Just node -> do
+            resp <- requestNode node (renderRequest requestData)
+            case resp of
+                (Error errString) | B.isPrefixOf "MOVED" errString -> do
+                    newShardMap <- refreshShardMap ()
+                    IOR.writeIORef shardMapRef newShardMap
+                    request shardMapRef refreshShardMap requestData
+                (askingRedirection -> Just (host, port)) -> do
+                    let maybeAskNode = nodeWithHostAndPort shardMap host port
+                    case maybeAskNode of
+                        Just askNode -> do
+                            _ <- requestNode askNode (renderRequest ["ASKING"])
+                            requestNode askNode (renderRequest requestData)
+                        Nothing -> do
+                            newShardMap <- refreshShardMap ()
+                            IOR.writeIORef shardMapRef newShardMap
+                            request shardMapRef refreshShardMap requestData
+                _ -> return resp
+
+askingRedirection :: Reply -> Maybe (Host, Port)
+askingRedirection (Error errString) = case Char8.words errString of
+    ["ASK", _, hostport] -> case Char8.split ':' hostport of
+       [host, portString] -> case Char8.readInt portString of
+         Just (port,"") -> Just (Char8.unpack host, port)
+         _ -> Nothing
+       _ -> Nothing
+    _ -> Nothing
+askingRedirection _ = Nothing
+
+
+nodeForCommand :: ShardMap -> [B.ByteString] -> Maybe Node
+nodeForCommand (ShardMap shards) (_:key:_) = do
+    (Shard master _) <- IntMap.lookup (fromEnum $ keyToSlot key) shards
+    Just master
+nodeForCommand _ _ = Nothing
+
+requestNode :: Node -> B.ByteString -> IO Reply
+requestNode (Node _ _ Connection{..} _ _) requestData = do
+    _ <- CC.send ctx requestData >> CC.flush ctx
+    maybeLastRecv <- IOR.readIORef lastRecvRef
+    scanResult <- case maybeLastRecv of
+        Just lastRecv -> Scanner.scanWith (CC.recv ctx) reply lastRecv
+        Nothing -> Scanner.scanWith (CC.recv ctx) reply B.empty
+
+
+    case scanResult of
+      Scanner.Fail{}       -> CC.errConnClosed
+      Scanner.More{}    -> error "Hedis: parseWith returned Partial"
+      Scanner.Done rest' r -> do
+        IOR.writeIORef lastRecvRef (Just rest')
+        return r
+
+nodes :: ShardMap -> [Node]
+nodes (ShardMap shardMap) = concatMap snd $ IntMap.toList $ fmap shardNodes shardMap where
+    shardNodes :: Shard -> [Node]
+    shardNodes (Shard master slaves) = master:slaves
+
+
+nodeWithHostAndPort :: ShardMap -> Host -> Port -> Maybe Node
+nodeWithHostAndPort shardMap host port = listToMaybe $ filter (\(Node _ _ _ nodeHost nodePort) -> port == nodePort && host == nodeHost) $ nodes shardMap

--- a/src/Database/Redis/Cluster/Command.hs
+++ b/src/Database/Redis/Cluster/Command.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE OverloadedStrings, RecordWildCards #-}
+module Database.Redis.Cluster.Command where
+
+import Data.Char(toLower)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as Char8
+import qualified Data.HashMap.Strict as HM
+import Database.Redis.Types(RedisResult(decode))
+import Database.Redis.Protocol(Reply(..))
+
+data Flag
+    = Write
+    | ReadOnly
+    | DenyOOM
+    | Admin
+    | PubSub
+    | NoScript
+    | Random
+    | SortForScript
+    | Loading
+    | Stale
+    | SkipMonitor
+    | Asking
+    | Fast
+    | MovableKeys
+    | Other BS.ByteString deriving (Show, Eq)
+
+
+data AritySpec = Required Integer | MinimumRequired Integer deriving (Show)
+
+data LastKeyPositionSpec = LastKeyPosition Integer | UnlimitedKeys deriving (Show)
+
+newtype InfoMap = InfoMap (HM.HashMap String CommandInfo)
+
+-- Represents the result of the COMMAND command, which returns information
+-- about the position of keys in a request
+data CommandInfo = CommandInfo
+    { name :: BS.ByteString
+    , arity :: AritySpec
+    , flags :: [Flag]
+    , firstKeyPosition :: Integer
+    , lastKeyPosition :: LastKeyPositionSpec
+    , stepCount :: Integer
+    } deriving (Show)
+
+instance RedisResult CommandInfo where
+    decode (MultiBulk (Just
+        [ Bulk (Just commandName)
+        , Integer aritySpec
+        , MultiBulk (Just replyFlags)
+        , Integer firstKeyPos
+        , Integer lastKeyPos
+        , Integer replyStepCount])) = do
+            parsedFlags <- mapM parseFlag replyFlags
+            lastKey <- parseLastKeyPos
+            return $ CommandInfo
+                { name = commandName
+                , arity = parseArity aritySpec
+                , flags = parsedFlags
+                , firstKeyPosition = firstKeyPos
+                , lastKeyPosition = lastKey
+                , stepCount = replyStepCount
+                } where
+        parseArity int = case int of
+            i | i >= 0 -> Required i
+            i -> MinimumRequired $ abs i
+        parseFlag :: Reply -> Either Reply Flag
+        parseFlag (SingleLine flag) = return $ case flag of
+            "write" -> Write
+            "readonly" -> ReadOnly
+            "denyoom" -> DenyOOM
+            "admin" -> Admin
+            "pubsub" -> PubSub
+            "noscript" -> NoScript
+            "random" -> Random
+            "sort_for_script" -> SortForScript
+            "loading" -> Loading
+            "stale" -> Stale
+            "skip_monitor" -> SkipMonitor
+            "asking" -> Asking
+            "fast" -> Fast
+            "movablekeys" -> MovableKeys
+            other -> Other other
+        parseFlag bad = Left bad
+        parseLastKeyPos :: Either Reply LastKeyPositionSpec
+        parseLastKeyPos = return $ case lastKeyPos of
+            i | i == -1 -> UnlimitedKeys
+            i -> LastKeyPosition i
+
+    decode e = Left e
+
+newInfoMap :: [CommandInfo] -> InfoMap
+newInfoMap = InfoMap . HM.fromList . map (\c -> (Char8.unpack $ name c, c))
+
+keysForRequest :: InfoMap -> [BS.ByteString] -> Maybe [BS.ByteString]
+keysForRequest (InfoMap infoMap) request@(command:_) = do
+    info <- HM.lookup (map toLower $ Char8.unpack command) infoMap
+    if isMovable info then return $ parseMovable request else do
+        let possibleKeys = case lastKeyPosition info of
+                LastKeyPosition end -> take (fromEnum $ 1 + end - firstKeyPosition info) $ drop (fromEnum $ firstKeyPosition info) request
+                UnlimitedKeys -> drop (fromEnum $ firstKeyPosition info) request
+        return $ takeEvery (fromEnum $ stepCount info) possibleKeys
+keysForRequest _ [] = Nothing
+
+isMovable :: CommandInfo -> Bool
+isMovable CommandInfo{..} = MovableKeys `elem` flags
+
+parseMovable :: [BS.ByteString] -> [BS.ByteString]
+parseMovable ("SORT":key:_) = [key]
+parseMovable ("EVAL":_:rest) = readNumKeys rest
+parseMovable ("EVALSH":_:rest) = readNumKeys rest
+parseMovable ("ZUNIONSTORE":_:rest) = readNumKeys rest
+parseMovable ("ZINTERSTORE":_:rest) = readNumKeys rest
+parseMovable _ = []
+
+
+readNumKeys :: [BS.ByteString] -> [BS.ByteString]
+readNumKeys (rawNumKeys:rest) = case readMaybe (Char8.unpack rawNumKeys) of
+    Just numKeys -> take numKeys rest
+    Nothing -> []
+readNumKeys _ = []
+
+takeEvery :: Int -> [a] -> [a]
+takeEvery n xs = case drop (n-1) xs of
+      (y:ys) -> y : takeEvery n ys
+      [] -> []
+
+readMaybe :: Read a => String -> Maybe a
+readMaybe s = case reads s of
+                  [(val, "")] -> Just val
+                  _           -> Nothing

--- a/src/Database/Redis/Cluster/HashSlot.hs
+++ b/src/Database/Redis/Cluster/HashSlot.hs
@@ -2,11 +2,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Database.Redis.Cluster.HashSlot(HashSlot, keyToSlot) where
 
-import Data.Bits((.&.))
+import Data.Bits((.&.), xor, shiftL)
 import qualified Data.ByteString.Char8 as Char8
 import qualified Data.ByteString as BS
-import Data.Word(Word16)
-import qualified Data.Digest.CRC16  as CRC16
+import Data.Word(Word8, Word16)
 
 newtype HashSlot = HashSlot Word16 deriving (Num, Eq, Ord, Real, Enum, Integral, Show)
 
@@ -26,5 +25,19 @@ findSubKey key = case Char8.break (=='{') key of
     (subKey, _) -> subKey
 
 crc16 :: BS.ByteString -> Word16
-crc16 = BS.foldl (CRC16.crc16_update 0x1021 False) 0
+crc16 = BS.foldl (crc16Update 0x1021) 0
 
+-- Taken from crc16 package
+crc16Update :: Word16  -- ^ polynomial
+            -> Word16 -- ^ initial crc
+            -> Word8 -- ^ data byte
+            -> Word16 -- ^ new crc
+crc16Update poly crc b = 
+  foldl crc16UpdateBit newCrc [1 :: Int .. 8]
+  where 
+    newCrc = crc `xor` shiftL (fromIntegral b :: Word16) 8
+    crc16UpdateBit crc' _ =
+      if (crc' .&. 0x8000) /= 0x0000
+          then shiftL crc' 1 `xor` poly
+          else shiftL crc' 1
+ 

--- a/src/Database/Redis/Cluster/HashSlot.hs
+++ b/src/Database/Redis/Cluster/HashSlot.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Database.Redis.Cluster.HashSlot(HashSlot, keyToSlot) where
+
+import Data.Bits((.&.))
+import qualified Data.ByteString.Char8 as Char8
+import qualified Data.ByteString as BS
+import Data.Word(Word16)
+import qualified Data.Digest.CRC16  as CRC16
+
+newtype HashSlot = HashSlot Word16 deriving (Num, Eq, Ord, Real, Enum, Integral, Show)
+
+numHashSlots :: Word16
+numHashSlots = 16384
+
+-- | Compute the hashslot associated with a key
+keyToSlot :: BS.ByteString -> HashSlot
+keyToSlot = HashSlot . (.&.) (numHashSlots - 1) . crc16 . findSubKey
+
+-- | Find the section of a key to compute the slot for.
+findSubKey :: BS.ByteString -> BS.ByteString
+findSubKey key = case Char8.break (=='{') key of
+  (whole, "") -> whole
+  (_, xs) -> case Char8.break (=='}') (Char8.tail xs) of
+    ("", _) -> key
+    (subKey, _) -> subKey
+
+crc16 :: BS.ByteString -> Word16
+crc16 = BS.foldl (CRC16.crc16_update 0x1021 False) 0
+

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -261,7 +261,19 @@ xinfoStream, -- |Get info about a stream. The Redis command @XINFO@ is split int
 xdel, -- |Delete messages from a stream. Since Redis 5.0.0
 xtrim, -- |Set the upper bound for number of messages in a stream. Since Redis 5.0.0
 inf, -- |Constructor for `inf` Redis argument values
-
+ClusterNodesResponse(..),
+ClusterNodesResponseEntry(..),
+ClusterNodesResponseSlotSpec(..),
+clusterNodes,
+ClusterSlotsResponse(..),
+ClusterSlotsResponseEntry(..),
+ClusterSlotsNode(..),
+clusterSlots,
+clusterSetSlotNode,
+clusterSetSlotStable,
+clusterSetSlotImporting,
+clusterSetSlotMigrating,
+clusterGetKeysInSlot
 -- * Unimplemented Commands
 -- |These commands are not implemented, as of now. Library
 --  users can implement these or other commands from
@@ -306,7 +318,7 @@ import Prelude hiding (min,max)
 import Data.ByteString (ByteString)
 import Database.Redis.ManualCommands
 import Database.Redis.Types
-import Database.Redis.Core
+import Database.Redis.Core(sendRequest, RedisCtx)
 
 ttl
     :: (RedisCtx m f)
@@ -1080,4 +1092,3 @@ sismember
     -> ByteString -- ^ member
     -> m (f Bool)
 sismember key member = sendRequest (["SISMEMBER"] ++ [encode key] ++ [encode member] )
-

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -273,7 +273,8 @@ clusterSetSlotNode,
 clusterSetSlotStable,
 clusterSetSlotImporting,
 clusterSetSlotMigrating,
-clusterGetKeysInSlot
+clusterGetKeysInSlot,
+command
 -- * Unimplemented Commands
 -- |These commands are not implemented, as of now. Library
 --  users can implement these or other commands from

--- a/src/Database/Redis/Connection.hs
+++ b/src/Database/Redis/Connection.hs
@@ -140,7 +140,7 @@ createConnection ConnInfo{..} = do
               _      -> return ()
     return conn'
 
--- |Constructs a 'Connection' pool to a Redis server designated by the 
+-- |Constructs a 'Connection' pool to a Redis server designated by the
 --  given 'ConnectInfo'. The first connection is not actually established
 --  until the first call to the server.
 connect :: ConnectInfo -> IO Connection
@@ -148,7 +148,7 @@ connect cInfo@ConnInfo{..} = NonClusteredConnection <$>
     createPool (createConnection cInfo) PP.disconnect 1 connectMaxIdleTime connectMaxConnections
 
 -- |Constructs a 'Connection' pool to a Redis server designated by the
---  given 'ConnectInfo', then tests if the server is actually there. 
+--  given 'ConnectInfo', then tests if the server is actually there.
 --  Throws an exception if the connection to the Redis server can't be
 --  established.
 checkedConnect :: ConnectInfo -> IO Connection
@@ -162,7 +162,7 @@ disconnect :: Connection -> IO ()
 disconnect (NonClusteredConnection pool) = destroyAllResources pool
 disconnect (ClusteredConnection _ pool) = destroyAllResources pool
 
--- | Memory bracket around 'connect' and 'disconnect'. 
+-- | Memory bracket around 'connect' and 'disconnect'.
 withConnect :: ConnectInfo -> (Connection -> IO c) -> IO c
 withConnect connInfo = bracket (connect connInfo) disconnect
 
@@ -178,7 +178,7 @@ withCheckedConnect connInfo = bracket (checkedConnect connInfo) disconnect
 runRedis :: Connection -> Redis a -> IO a
 runRedis (NonClusteredConnection pool) redis =
   withResource pool $ \conn -> runRedisInternal conn redis
-runRedis (ClusteredConnection _ pool) redis = 
+runRedis (ClusteredConnection _ pool) redis =
     withResource pool $ \conn -> runRedisClusteredInternal conn (refreshShardMap conn) redis
 
 newtype ClusterConnectError = ClusterConnectError Reply
@@ -198,7 +198,7 @@ connectCluster bootstrapConnInfo = do
             shardMap <- shardMapFromClusterSlotsResponse slots
             newMVar shardMap
     commandInfos <- runRedisInternal conn command
-    case commandInfos of 
+    case commandInfos of
         Left e -> throwIO $ ClusterConnectError e
         Right infos -> do
             pool <- createPool (Cluster.connect infos shardMapVar Nothing) Cluster.disconnect 1 (connectMaxIdleTime bootstrapConnInfo) (connectMaxConnections bootstrapConnInfo)
@@ -218,7 +218,7 @@ shardMapFromClusterSlotsResponse ClusterSlotsResponse{..} = ShardMap <$> foldr m
     nodeFromClusterSlotNode isMaster ClusterSlotsNode{..} =
         let hostname = Char8.unpack clusterSlotsNodeIP
             role = if isMaster then Cluster.Master else Cluster.Slave
-        in 
+        in
             Cluster.Node clusterSlotsNodeID role hostname (toEnum clusterSlotsNodePort)
 
 refreshShardMap :: Cluster.Connection -> IO ShardMap

--- a/src/Database/Redis/Connection.hs
+++ b/src/Database/Redis/Connection.hs
@@ -1,0 +1,220 @@
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Database.Redis.Connection where
+
+import Control.Exception
+import Control.Monad.IO.Class(liftIO)
+import Control.Monad(when)
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as Char8
+import Data.Functor(void)
+import qualified Data.IntMap.Strict as IntMap
+import Data.Pool(Pool, withResource, createPool, destroyAllResources)
+import Data.Typeable
+import qualified Data.IORef as IOR
+import qualified Data.Time as Time
+import Network.TLS (ClientParams)
+import qualified Network.Socket as NS
+
+import qualified Database.Redis.ProtocolPipelining as PP
+import Database.Redis.Core(Redis, runRedisInternal, runRedisClusteredInternal)
+import Database.Redis.Protocol(Reply(..))
+import Database.Redis.Cluster(ShardMap(..), Node, Shard(..))
+import qualified Database.Redis.Cluster as Cluster
+import qualified Database.Redis.ConnectionContext as CC
+import Database.Redis.Commands
+    ( ping
+    , select
+    , auth
+    , clusterSlots
+    , ClusterSlotsResponse(..)
+    , ClusterSlotsResponseEntry(..)
+    , ClusterSlotsNode(..))
+
+--------------------------------------------------------------------------------
+-- Connection
+--
+
+-- |A threadsafe pool of network connections to a Redis server. Use the
+--  'connect' function to create one.
+data Connection
+    = NonClusteredConnection (Pool PP.Connection)
+    | ClusteredConnection (IOR.IORef ShardMap)
+
+-- |Information for connnecting to a Redis server.
+--
+-- It is recommended to not use the 'ConnInfo' data constructor directly.
+-- Instead use 'defaultConnectInfo' and update it with record syntax. For
+-- example to connect to a password protected Redis server running on localhost
+-- and listening to the default port:
+--
+-- @
+-- myConnectInfo :: ConnectInfo
+-- myConnectInfo = defaultConnectInfo {connectAuth = Just \"secret\"}
+-- @
+--
+data ConnectInfo = ConnInfo
+    { connectHost           :: NS.HostName
+    , connectPort           :: CC.PortID
+    , connectAuth           :: Maybe B.ByteString
+    -- ^ When the server is protected by a password, set 'connectAuth' to 'Just'
+    --   the password. Each connection will then authenticate by the 'auth'
+    --   command.
+    , connectDatabase       :: Integer
+    -- ^ Each connection will 'select' the database with the given index.
+    , connectMaxConnections :: Int
+    -- ^ Maximum number of connections to keep open. The smallest acceptable
+    --   value is 1.
+    , connectMaxIdleTime    :: Time.NominalDiffTime
+    -- ^ Amount of time for which an unused connection is kept open. The
+    --   smallest acceptable value is 0.5 seconds. If the @timeout@ value in
+    --   your redis.conf file is non-zero, it should be larger than
+    --   'connectMaxIdleTime'.
+    , connectTimeout        :: Maybe Time.NominalDiffTime
+    -- ^ Optional timeout until connection to Redis gets
+    --   established. 'ConnectTimeoutException' gets thrown if no socket
+    --   get connected in this interval of time.
+    , connectTLSParams      :: Maybe ClientParams
+    -- ^ Optional TLS parameters. TLS will be enabled if this is provided.
+    } deriving Show
+
+data ConnectError = ConnectAuthError Reply
+                  | ConnectSelectError Reply
+    deriving (Eq, Show, Typeable)
+
+instance Exception ConnectError
+
+-- |Default information for connecting:
+--
+-- @
+--  connectHost           = \"localhost\"
+--  connectPort           = PortNumber 6379 -- Redis default port
+--  connectAuth           = Nothing         -- No password
+--  connectDatabase       = 0               -- SELECT database 0
+--  connectMaxConnections = 50              -- Up to 50 connections
+--  connectMaxIdleTime    = 30              -- Keep open for 30 seconds
+--  connectTimeout        = Nothing         -- Don't add timeout logic
+--  connectTLSParams      = Nothing         -- Do not use TLS
+-- @
+--
+defaultConnectInfo :: ConnectInfo
+defaultConnectInfo = ConnInfo
+    { connectHost           = "localhost"
+    , connectPort           = CC.PortNumber 6379
+    , connectAuth           = Nothing
+    , connectDatabase       = 0
+    , connectMaxConnections = 50
+    , connectMaxIdleTime    = 30
+    , connectTimeout        = Nothing
+    , connectTLSParams      = Nothing
+    }
+
+createConnection :: ConnectInfo -> IO PP.Connection
+createConnection ConnInfo{..} = do
+    let timeoutOptUs =
+          round . (1000000 *) <$> connectTimeout
+    conn <- PP.connect connectHost connectPort timeoutOptUs
+    conn' <- case connectTLSParams of
+               Nothing -> return conn
+               Just tlsParams -> PP.enableTLS tlsParams conn
+    PP.beginReceiving conn'
+
+    runRedisInternal conn' $ do
+        -- AUTH
+        case connectAuth of
+            Nothing   -> return ()
+            Just pass -> do
+              resp <- auth pass
+              case resp of
+                Left r -> liftIO $ throwIO $ ConnectAuthError r
+                _      -> return ()
+        -- SELECT
+        when (connectDatabase /= 0) $ do
+          resp <- select connectDatabase
+          case resp of
+              Left r -> liftIO $ throwIO $ ConnectSelectError r
+              _      -> return ()
+    return conn'
+
+-- |Constructs a 'Connection' pool to a Redis server designated by the 
+--  given 'ConnectInfo'. The first connection is not actually established
+--  until the first call to the server.
+connect :: ConnectInfo -> IO Connection
+connect cInfo@ConnInfo{..} = NonClusteredConnection <$>
+    createPool (createConnection cInfo) PP.disconnect 1 connectMaxIdleTime connectMaxConnections
+
+-- |Constructs a 'Connection' pool to a Redis server designated by the
+--  given 'ConnectInfo', then tests if the server is actually there. 
+--  Throws an exception if the connection to the Redis server can't be
+--  established.
+checkedConnect :: ConnectInfo -> IO Connection
+checkedConnect connInfo = do
+    conn <- connect connInfo
+    runRedis conn $ void ping
+    return conn
+
+-- |Destroy all idle resources in the pool.
+disconnect :: Connection -> IO ()
+disconnect (NonClusteredConnection pool) = destroyAllResources pool
+disconnect (ClusteredConnection _) = return ()
+
+-- | Memory bracket around 'connect' and 'disconnect'. 
+withConnect :: ConnectInfo -> (Connection -> IO c) -> IO c
+withConnect connInfo = bracket (connect connInfo) disconnect
+
+-- | Memory bracket around 'checkedConnect' and 'disconnect'
+withCheckedConnect :: ConnectInfo -> (Connection -> IO c) -> IO c
+withCheckedConnect connInfo = bracket (checkedConnect connInfo) disconnect
+
+-- |Interact with a Redis datastore specified by the given 'Connection'.
+--
+--  Each call of 'runRedis' takes a network connection from the 'Connection'
+--  pool and runs the given 'Redis' action. Calls to 'runRedis' may thus block
+--  while all connections from the pool are in use.
+runRedis :: Connection -> Redis a -> IO a
+runRedis (NonClusteredConnection pool) redis =
+  withResource pool $ \conn -> runRedisInternal conn redis
+runRedis c@(ClusteredConnection shardMapRef) redis = runRedisClusteredInternal shardMapRef (\() -> refreshShardMap c) redis
+
+newtype ClusterConnectError = ClusterConnectError Reply
+    deriving (Eq, Show, Typeable)
+
+instance Exception ClusterConnectError
+
+-- |Constructs a 'ShardMap' of connections to clustered nodes. The argument is
+-- a 'ConnectInfo' for any node in the cluster
+connectCluster :: ConnectInfo -> IO Connection
+connectCluster bootstrapConnInfo = do
+    conn <- createConnection bootstrapConnInfo
+    slotsResponse <- runRedisInternal conn clusterSlots
+    case slotsResponse of
+        Left e -> throwIO $ ClusterConnectError e
+        Right slots -> do
+            shardMap <- shardMapFromClusterSlotsResponse slots
+            shardMapRef <- IOR.newIORef shardMap
+            return $ ClusteredConnection shardMapRef
+
+shardMapFromClusterSlotsResponse :: ClusterSlotsResponse -> IO ShardMap
+shardMapFromClusterSlotsResponse ClusterSlotsResponse{..} = ShardMap <$> foldr mkShardMap (pure IntMap.empty)  clusterSlotsResponseEntries where
+    mkShardMap :: ClusterSlotsResponseEntry -> IO (IntMap.IntMap Shard) -> IO (IntMap.IntMap Shard)
+    mkShardMap ClusterSlotsResponseEntry{..} accumulator = do
+        accumulated <- accumulator
+        master <- nodeFromClusterSlotNode True clusterSlotsResponseEntryMaster
+        replicas <- mapM (nodeFromClusterSlotNode False) clusterSlotsResponseEntryReplicas
+        let shard = Shard master replicas
+        let slotMap = IntMap.fromList $ map (, shard) [clusterSlotsResponseEntryStartSlot..clusterSlotsResponseEntryEndSlot]
+        return $ IntMap.union slotMap accumulated
+    nodeFromClusterSlotNode :: Bool -> ClusterSlotsNode -> IO Node
+    nodeFromClusterSlotNode isMaster ClusterSlotsNode{..} = do
+        let hostname = Char8.unpack clusterSlotsNodeIP
+        conn <- Cluster.connect hostname (toEnum clusterSlotsNodePort) Nothing
+        let role = if isMaster then Cluster.Master else Cluster.Slave
+        return $ Cluster.Node clusterSlotsNodeID role conn hostname (toEnum clusterSlotsNodePort)
+
+refreshShardMap :: Connection -> IO ShardMap
+refreshShardMap conn = do
+    slotsResponse <- runRedis conn clusterSlots
+    case slotsResponse of
+        Left e -> throwIO $ ClusterConnectError e
+        Right slots -> shardMapFromClusterSlotsResponse slots

--- a/src/Database/Redis/ConnectionContext.hs
+++ b/src/Database/Redis/ConnectionContext.hs
@@ -1,0 +1,162 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Database.Redis.ConnectionContext (
+    ConnectionContext(..)
+  , ConnectTimeout(..)
+  , ConnectionLostException(..)
+  , PortID(..)
+  , connect
+  , disconnect
+  , send
+  , recv 
+  , errConnClosed
+  , enableTLS
+  , flush
+  , ioErrorToConnLost
+) where
+
+import           Control.Concurrent (threadDelay)
+import           Control.Concurrent.Async (race)
+import Control.Monad(when)
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as LB
+import qualified Data.IORef as IOR
+import Control.Concurrent.MVar(newMVar, readMVar, swapMVar)
+import Control.Exception(bracketOnError, Exception, throwIO, try)
+import           Data.Typeable
+import Data.Functor(void)
+import qualified Network.Socket as NS
+import qualified Network.TLS as TLS
+import System.IO(Handle, hSetBinaryMode, hClose, IOMode(..), hFlush, hIsOpen)
+import System.IO.Error(catchIOError)
+
+data ConnectionContext = NormalHandle Handle | TLSContext TLS.Context
+
+instance Show ConnectionContext where
+    show (NormalHandle _) = "NormalHandle"
+    show (TLSContext _) = "TLSContext"
+
+data Connection = Connection
+    { ctx :: ConnectionContext
+    , lastRecvRef :: IOR.IORef (Maybe B.ByteString) }
+
+instance Show Connection where
+    show Connection{..} = "Connection{ ctx = " <> show ctx <> ", lastRecvRef = IORef}"
+
+data ConnectPhase
+  = PhaseUnknown
+  | PhaseResolve
+  | PhaseOpenSocket
+  deriving (Show)
+
+newtype ConnectTimeout = ConnectTimeout ConnectPhase
+  deriving (Show, Typeable)
+
+instance Exception ConnectTimeout
+
+data ConnectionLostException = ConnectionLost deriving Show
+instance Exception ConnectionLostException
+
+data PortID = PortNumber NS.PortNumber
+            | UnixSocket String
+            deriving Show
+
+connect :: NS.HostName -> PortID -> Maybe Int -> IO ConnectionContext
+connect hostName portId timeoutOpt =
+  bracketOnError hConnect hClose $ \h -> do
+    hSetBinaryMode h True
+    return $ NormalHandle h
+  where
+        hConnect = do
+          phaseMVar <- newMVar PhaseUnknown
+          let doConnect = hConnect' phaseMVar
+          case timeoutOpt of
+            Nothing -> doConnect
+            Just micros -> do
+              result <- race doConnect (threadDelay micros)
+              case result of
+                Left h -> return h
+                Right () -> do
+                  phase <- readMVar phaseMVar
+                  errConnectTimeout phase
+        hConnect' mvar = bracketOnError createSock NS.close $ \sock -> do
+          NS.setSocketOption sock NS.KeepAlive 1
+          void $ swapMVar mvar PhaseResolve
+          void $ swapMVar mvar PhaseOpenSocket
+          NS.socketToHandle sock ReadWriteMode
+          where
+            createSock = case portId of
+              PortNumber portNumber -> do
+                addrInfo <- getHostAddrInfo hostName portNumber
+                connectSocket addrInfo
+              UnixSocket addr -> bracketOnError
+                (NS.socket NS.AF_UNIX NS.Stream NS.defaultProtocol)
+                NS.close
+                (\sock -> NS.connect sock (NS.SockAddrUnix addr) >> return sock)
+
+getHostAddrInfo :: NS.HostName -> NS.PortNumber -> IO [NS.AddrInfo]
+getHostAddrInfo hostname port =
+  NS.getAddrInfo (Just hints) (Just hostname) (Just $ show port)
+  where
+    hints = NS.defaultHints
+      { NS.addrSocketType = NS.Stream }
+
+errConnectTimeout :: ConnectPhase -> IO a
+errConnectTimeout phase = throwIO $ ConnectTimeout phase
+
+connectSocket :: [NS.AddrInfo] -> IO NS.Socket
+connectSocket [] = error "connectSocket: unexpected empty list"
+connectSocket (addr:rest) = tryConnect >>= \case
+  Right sock -> return sock
+  Left err   -> if null rest
+                then throwIO err
+                else connectSocket rest
+  where
+    tryConnect :: IO (Either IOError NS.Socket)
+    tryConnect = bracketOnError createSock NS.close $ \sock ->
+      try (NS.connect sock $ NS.addrAddress addr) >>= \case
+      Right () -> return (Right sock)
+      Left err -> return (Left err)
+      where
+        createSock = NS.socket (NS.addrFamily addr)
+                               (NS.addrSocketType addr)
+                               (NS.addrProtocol addr)
+
+send :: ConnectionContext -> B.ByteString -> IO ()
+send (NormalHandle h) requestData =
+      ioErrorToConnLost (B.hPut h requestData) 
+send (TLSContext ctx) requestData =
+        ioErrorToConnLost (TLS.sendData ctx (LB.fromStrict requestData)) 
+
+recv :: ConnectionContext -> IO B.ByteString
+recv (NormalHandle h) = ioErrorToConnLost $ B.hGetSome h 4096
+recv (TLSContext ctx) = TLS.recvData ctx
+
+
+ioErrorToConnLost :: IO a -> IO a
+ioErrorToConnLost a = a `catchIOError` const errConnClosed
+
+errConnClosed :: IO a
+errConnClosed = throwIO ConnectionLost
+
+
+enableTLS :: TLS.ClientParams -> ConnectionContext -> IO ConnectionContext
+enableTLS tlsParams (NormalHandle h) = do
+  ctx <- TLS.contextNew h tlsParams
+  TLS.handshake ctx
+  return $ TLSContext ctx
+enableTLS _ c@(TLSContext _) = return c
+
+disconnect :: ConnectionContext -> IO ()
+disconnect (NormalHandle h) = do
+  open <- hIsOpen h
+  when open $ hClose h
+disconnect (TLSContext ctx) = do
+  TLS.bye ctx
+  TLS.contextClose ctx
+
+flush :: ConnectionContext -> IO ()
+flush (NormalHandle h) = hFlush h
+flush (TLSContext c) = TLS.contextFlush c

--- a/src/Database/Redis/Core.hs
+++ b/src/Database/Redis/Core.hs
@@ -3,36 +3,30 @@
     DeriveDataTypeable, StandaloneDeriving #-}
 
 module Database.Redis.Core (
-    Connection(..), ConnectError(..), connect, checkedConnect, disconnect,
-    withConnect, withCheckedConnect,
-    ConnectInfo(..), defaultConnectInfo,
-    Redis(), runRedis, unRedis, reRedis,
+    Redis(), unRedis, reRedis,
     RedisCtx(..), MonadRedis(..),
     send, recv, sendRequest,
-    auth, select, ping
+    runRedisInternal,
+    runRedisClusteredInternal,
+    RedisEnv(..),
 ) where
 
 import Prelude
 #if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
 #endif
-import Control.Exception
 #if __GLASGOW_HASKELL__ > 711
-import Control.Monad.Fail (MonadFail)
 #endif
 import Control.Monad.Reader
+import Control.Monad.Fail(MonadFail)
 import qualified Data.ByteString as B
 import Data.IORef
-import Data.Pool
-import Data.Time
-import Data.Typeable
-import qualified Network.Socket as NS
-import Network.TLS (ClientParams)
 
 import Database.Redis.Protocol
 import qualified Database.Redis.ProtocolPipelining as PP
 import Database.Redis.Types
-
+import Database.Redis.Cluster(ShardMap)
+import qualified Database.Redis.Cluster as Cluster
 
 --------------------------------------------------------------------------------
 -- The Redis Monad
@@ -50,7 +44,9 @@ newtype Redis a = Redis (ReaderT RedisEnv IO a)
 deriving instance MonadFail Redis
 #endif
 
-data RedisEnv = Env { envConn :: PP.Connection, envLastReply :: IORef Reply }
+data RedisEnv
+    = NonClusteredEnv { envConn :: PP.Connection, envLastReply :: IORef Reply }
+    | ClusteredEnv { currentShardMap :: IORef ShardMap, refreshAction :: () -> IO ShardMap }
 
 -- |This class captures the following behaviour: In a context @m@, a command
 --  will return its result wrapped in a \"container\" of type @f@.
@@ -60,23 +56,15 @@ data RedisEnv = Env { envConn :: PP.Connection, envLastReply :: IORef Reply }
 class (MonadRedis m) => RedisCtx m f | m -> f where
     returnDecode :: RedisResult a => Reply -> m (f a)
 
-instance RedisCtx Redis (Either Reply) where
-    returnDecode = return . decode
-
 class (Monad m) => MonadRedis m where
     liftRedis :: Redis a -> m a
 
+
+instance RedisCtx Redis (Either Reply) where
+    returnDecode = return . decode
+
 instance MonadRedis Redis where
     liftRedis = id
-
--- |Interact with a Redis datastore specified by the given 'Connection'.
---
---  Each call of 'runRedis' takes a network connection from the 'Connection'
---  pool and runs the given 'Redis' action. Calls to 'runRedis' may thus block
---  while all connections from the pool are in use.
-runRedis :: Connection -> Redis a -> IO a
-runRedis (Conn pool) redis =
-  withResource pool $ \conn -> runRedisInternal conn redis
 
 -- |Deconstruct Redis constructor.
 --
@@ -98,10 +86,13 @@ runRedisInternal :: PP.Connection -> Redis a -> IO a
 runRedisInternal conn (Redis redis) = do
   -- Dummy reply in case no request is sent.
   ref <- newIORef (SingleLine "nobody will ever see this")
-  r <- runReaderT redis (Env conn ref)
+  r <- runReaderT redis (NonClusteredEnv conn ref)
   -- Evaluate last reply to keep lazy IO inside runRedis.
   readIORef ref >>= (`seq` return ())
   return r
+
+runRedisClusteredInternal :: IORef ShardMap -> (() -> IO ShardMap) -> Redis a -> IO a
+runRedisClusteredInternal shardMapRef refreshShardmapAction (Redis redis) = runReaderT redis (ClusteredEnv shardMapRef refreshShardmapAction) 
 
 setLastReply :: Reply -> ReaderT RedisEnv IO ()
 setLastReply r = do
@@ -134,161 +125,11 @@ sendRequest :: (RedisCtx m f, RedisResult a)
     => [B.ByteString] -> m (f a)
 sendRequest req = do
     r' <- liftRedis $ Redis $ do
-        conn <- asks envConn
-        r <- liftIO $ PP.request conn (renderRequest req)
-        setLastReply r
-        return r
+        env <- ask
+        case env of 
+            NonClusteredEnv{..} -> do
+                r <- liftIO $ PP.request envConn (renderRequest req)
+                setLastReply r
+                return r
+            ClusteredEnv{..} -> liftIO $ Cluster.request currentShardMap refreshAction req
     returnDecode r'
-
-
---------------------------------------------------------------------------------
--- Connection
---
-
--- |A threadsafe pool of network connections to a Redis server. Use the
---  'connect' function to create one.
-newtype Connection = Conn (Pool PP.Connection)
-
--- |Information for connnecting to a Redis server.
---
--- It is recommended to not use the 'ConnInfo' data constructor directly.
--- Instead use 'defaultConnectInfo' and update it with record syntax. For
--- example to connect to a password protected Redis server running on localhost
--- and listening to the default port:
---
--- @
--- myConnectInfo :: ConnectInfo
--- myConnectInfo = defaultConnectInfo {connectAuth = Just \"secret\"}
--- @
---
-data ConnectInfo = ConnInfo
-    { connectHost           :: NS.HostName
-    , connectPort           :: PP.PortID
-    , connectAuth           :: Maybe B.ByteString
-    -- ^ When the server is protected by a password, set 'connectAuth' to 'Just'
-    --   the password. Each connection will then authenticate by the 'auth'
-    --   command.
-    , connectDatabase       :: Integer
-    -- ^ Each connection will 'select' the database with the given index.
-    , connectMaxConnections :: Int
-    -- ^ Maximum number of connections to keep open. The smallest acceptable
-    --   value is 1.
-    , connectMaxIdleTime    :: NominalDiffTime
-    -- ^ Amount of time for which an unused connection is kept open. The
-    --   smallest acceptable value is 0.5 seconds. If the @timeout@ value in
-    --   your redis.conf file is non-zero, it should be larger than
-    --   'connectMaxIdleTime'.
-    , connectTimeout        :: Maybe NominalDiffTime
-    -- ^ Optional timeout until connection to Redis gets
-    --   established. 'ConnectTimeoutException' gets thrown if no socket
-    --   get connected in this interval of time.
-    , connectTLSParams      :: Maybe ClientParams
-    -- ^ Optional TLS parameters. TLS will be enabled if this is provided.
-    } deriving Show
-
-data ConnectError = ConnectAuthError Reply
-                  | ConnectSelectError Reply
-    deriving (Eq, Show, Typeable)
-
-instance Exception ConnectError
-
--- |Default information for connecting:
---
--- @
---  connectHost           = \"localhost\"
---  connectPort           = PortNumber 6379 -- Redis default port
---  connectAuth           = Nothing         -- No password
---  connectDatabase       = 0               -- SELECT database 0
---  connectMaxConnections = 50              -- Up to 50 connections
---  connectMaxIdleTime    = 30              -- Keep open for 30 seconds
---  connectTimeout        = Nothing         -- Don't add timeout logic
---  connectTLSParams      = Nothing         -- Do not use TLS
--- @
---
-defaultConnectInfo :: ConnectInfo
-defaultConnectInfo = ConnInfo
-    { connectHost           = "localhost"
-    , connectPort           = PP.PortNumber 6379
-    , connectAuth           = Nothing
-    , connectDatabase       = 0
-    , connectMaxConnections = 50
-    , connectMaxIdleTime    = 30
-    , connectTimeout        = Nothing
-    , connectTLSParams      = Nothing
-    }
-
--- |Constructs a 'Connection' pool to a Redis server designated by the 
---  given 'ConnectInfo'. The first connection is not actually established
---  until the first call to the server.
-connect :: ConnectInfo -> IO Connection
-connect ConnInfo{..} = Conn <$>
-    createPool create destroy 1 connectMaxIdleTime connectMaxConnections
-  where
-    create = do
-        let timeoutOptUs =
-              round . (1000000 *) <$> connectTimeout
-        conn <- PP.connect connectHost connectPort timeoutOptUs
-        conn' <- case connectTLSParams of
-                   Nothing -> return conn
-                   Just tlsParams -> PP.enableTLS tlsParams conn
-        PP.beginReceiving conn'
-
-        runRedisInternal conn' $ do
-            -- AUTH
-            case connectAuth of
-                Nothing   -> return ()
-                Just pass -> do
-                  resp <- auth pass
-                  case resp of
-                    Left r -> liftIO $ throwIO $ ConnectAuthError r
-                    _      -> return ()
-            -- SELECT
-            when (connectDatabase /= 0) $ do
-              resp <- select connectDatabase
-              case resp of
-                  Left r -> liftIO $ throwIO $ ConnectSelectError r
-                  _      -> return ()
-        return conn'
-
-    destroy = PP.disconnect
-
--- |Constructs a 'Connection' pool to a Redis server designated by the
---  given 'ConnectInfo', then tests if the server is actually there. 
---  Throws an exception if the connection to the Redis server can't be
---  established.
-checkedConnect :: ConnectInfo -> IO Connection
-checkedConnect connInfo = do
-    conn <- connect connInfo
-    runRedis conn $ void ping
-    return conn
-
--- |Destroy all idle resources in the pool.
-disconnect :: Connection -> IO ()
-disconnect (Conn pool) = destroyAllResources pool
-
--- | Memory bracket around 'connect' and 'disconnect'. 
-withConnect :: ConnectInfo -> (Connection -> IO c) -> IO c
-withConnect connInfo = bracket (connect connInfo) disconnect
-
--- | Memory bracket around 'checkedConnect' and 'disconnect'
-withCheckedConnect :: ConnectInfo -> (Connection -> IO c) -> IO c
-withCheckedConnect connInfo = bracket (checkedConnect connInfo) disconnect
-
--- The AUTH command. It has to be here because it is used in 'connect'.
-auth
-    :: B.ByteString -- ^ password
-    -> Redis (Either Reply Status)
-auth password = sendRequest ["AUTH", password]
-
--- The SELECT command. Used in 'connect'.
-select
-    :: RedisCtx m f
-    => Integer -- ^ index
-    -> m (f Status)
-select ix = sendRequest ["SELECT", encode ix]
-
--- The PING command. Used in 'checkedConnect'.
-ping
-    :: (RedisCtx m f)
-    => m (f Status)
-ping  = sendRequest (["PING"] )

--- a/src/Database/Redis/Core.hs
+++ b/src/Database/Redis/Core.hs
@@ -18,7 +18,11 @@ import Control.Applicative
 #if __GLASGOW_HASKELL__ > 711
 #endif
 import Control.Monad.Reader
+#if MIN_VERSION_base(4,13,0)
+
+#else
 import Control.Monad.Fail(MonadFail)
+#endif
 import qualified Data.ByteString as B
 import Data.IORef
 

--- a/src/Database/Redis/Core.hs
+++ b/src/Database/Redis/Core.hs
@@ -50,8 +50,8 @@ deriving instance MonadFail Redis
 
 data RedisEnv
     = NonClusteredEnv { envConn :: PP.Connection, envLastReply :: IORef Reply }
-    | ClusteredEnv 
-        { refreshAction :: IO ShardMap 
+    | ClusteredEnv
+        { refreshAction :: IO ShardMap
         , connection :: Cluster.Connection
         }
 
@@ -77,7 +77,7 @@ instance MonadRedis Redis where
 --
 --  'unRedis' and 'reRedis' can be used to define instances for
 --  arbitrary typeclasses.
--- 
+--
 --  WARNING! These functions are considered internal and no guarantee
 --  is given at this point that they will not break in future.
 unRedis :: Redis a -> ReaderT RedisEnv IO a
@@ -100,7 +100,7 @@ runRedisInternal conn (Redis redis) = do
 
 runRedisClusteredInternal :: Cluster.Connection -> IO ShardMap -> Redis a -> IO a
 runRedisClusteredInternal connection refreshShardmapAction (Redis redis) = do
-    r <- runReaderT redis (ClusteredEnv refreshShardmapAction connection) 
+    r <- runReaderT redis (ClusteredEnv refreshShardmapAction connection)
     r `seq` return ()
     return r
 
@@ -136,7 +136,7 @@ sendRequest :: (RedisCtx m f, RedisResult a)
 sendRequest req = do
     r' <- liftRedis $ Redis $ do
         env <- ask
-        case env of 
+        case env of
             NonClusteredEnv{..} -> do
                 r <- liftIO $ PP.request envConn (renderRequest req)
                 setLastReply r

--- a/src/Database/Redis/ManualCommands.hs
+++ b/src/Database/Redis/ManualCommands.hs
@@ -10,6 +10,7 @@ import Data.Maybe (maybeToList, catMaybes)
 import Database.Redis.Core
 import Database.Redis.Protocol
 import Database.Redis.Types
+import qualified Database.Redis.Cluster.Command as CMD
 
 
 objectRefcount
@@ -1374,3 +1375,6 @@ clusterGetKeysInSlot
     -> Integer
     -> m (f [ByteString])
 clusterGetKeysInSlot slot count = sendRequest ["CLUSTER", "GETKEYSINSLOT", (encode slot), (encode count)]
+
+command :: (RedisCtx m f) => m (f [CMD.CommandInfo])
+command = sendRequest ["COMMAND"]

--- a/src/Database/Redis/ManualCommands.hs
+++ b/src/Database/Redis/ManualCommands.hs
@@ -4,7 +4,9 @@ module Database.Redis.ManualCommands where
 
 import Prelude hiding (min, max)
 import Data.ByteString (ByteString, empty, append)
-import Data.Maybe (maybeToList)
+import qualified Data.ByteString.Char8 as Char8
+import qualified Data.ByteString as BS
+import Data.Maybe (maybeToList, catMaybes)
 import Database.Redis.Core
 import Database.Redis.Protocol
 import Database.Redis.Types
@@ -1197,3 +1199,178 @@ xtrim stream opts = sendRequest $ ["XTRIM", stream] ++ optArgs
 
 inf :: RealFloat a => a
 inf = 1 / 0
+
+auth
+    :: RedisCtx m f
+    => ByteString -- ^ password
+    -> m (f Status)
+auth password = sendRequest ["AUTH", password]
+
+-- the select command. used in 'connect'.
+select
+    :: RedisCtx m f
+    => Integer -- ^ index
+    -> m (f Status)
+select ix = sendRequest ["SELECT", encode ix]
+
+-- the ping command. used in 'checkedconnect'.
+ping
+    :: (RedisCtx m f)
+    => m (f Status)
+ping  = sendRequest (["PING"] )
+
+data ClusterNodesResponse = ClusterNodesResponse
+    { clusterNodesResponseEntries :: [ClusterNodesResponseEntry]
+    } deriving (Show, Eq)
+
+data ClusterNodesResponseEntry = ClusterNodesResponseEntry { clusterNodesResponseNodeId :: ByteString
+    , clusterNodesResponseNodeIp :: ByteString
+    , clusterNodesResponseNodePort :: Integer
+    , clusterNodesResponseNodeFlags :: [ByteString]
+    , clusterNodesResponseMasterId :: Maybe ByteString
+    , clusterNodesResponsePingSent :: Integer
+    , clusterNodesResponsePongReceived :: Integer
+    , clusterNodesResponseConfigEpoch :: Integer
+    , clusterNodesResponseLinkState :: ByteString
+    , clusterNodesResponseSlots :: [ClusterNodesResponseSlotSpec]
+    } deriving (Show, Eq)
+
+data ClusterNodesResponseSlotSpec
+    = ClusterNodesResponseSingleSlot Integer
+    | ClusterNodesResponseSlotRange Integer Integer
+    | ClusterNodesResponseSlotImporting Integer ByteString
+    | ClusterNodesResponseSlotMigrating Integer ByteString deriving (Show, Eq)
+
+
+instance RedisResult ClusterNodesResponse where
+    decode r@(Bulk (Just bulkData)) = maybe (Left r) Right $ do
+        infos <- mapM parseNodeInfo $ Char8.lines bulkData
+        return $ ClusterNodesResponse infos where
+            parseNodeInfo :: ByteString -> Maybe ClusterNodesResponseEntry
+            parseNodeInfo line = case Char8.words line of
+              (nodeId : hostNamePort : flags : masterNodeId : pingSent : pongRecv : epoch : linkState : slots) ->
+                case Char8.split ':' hostNamePort of
+                  [hostName, port] -> ClusterNodesResponseEntry <$> pure nodeId
+                                               <*> pure hostName
+                                               <*> readInteger port
+                                               <*> pure (Char8.split ',' flags)
+                                               <*> pure (readMasterNodeId masterNodeId)
+                                               <*> readInteger pingSent
+                                               <*> readInteger pongRecv
+                                               <*> readInteger epoch
+                                               <*> pure linkState
+                                               <*> (pure . catMaybes $ map readNodeSlot slots)
+                  _ -> Nothing
+              _ -> Nothing
+            readInteger :: ByteString -> Maybe Integer
+            readInteger = fmap fst . Char8.readInteger
+
+            readMasterNodeId :: ByteString -> Maybe ByteString
+            readMasterNodeId "-"    = Nothing
+            readMasterNodeId nodeId = Just nodeId
+
+            readNodeSlot :: ByteString -> Maybe ClusterNodesResponseSlotSpec
+            readNodeSlot slotSpec = case '[' `Char8.elem` slotSpec of
+                True -> readSlotImportMigrate slotSpec
+                False -> case '-' `Char8.elem` slotSpec of
+                    True -> readSlotRange slotSpec
+                    False -> ClusterNodesResponseSingleSlot <$> readInteger slotSpec
+            readSlotImportMigrate :: ByteString -> Maybe ClusterNodesResponseSlotSpec
+            readSlotImportMigrate slotSpec = case BS.breakSubstring "->-" slotSpec of
+                (_, "") -> case BS.breakSubstring "-<-" slotSpec of
+                    (_, "") -> Nothing
+                    (leftPart, rightPart) -> ClusterNodesResponseSlotImporting
+                        <$> (readInteger $ Char8.drop 1 leftPart)
+                        <*> (pure $ BS.take (BS.length rightPart - 1) rightPart)
+                (leftPart, rightPart) -> ClusterNodesResponseSlotMigrating
+                    <$> (readInteger $ Char8.drop 1 leftPart)
+                    <*> (pure $ BS.take (BS.length rightPart - 1) rightPart)
+            readSlotRange :: ByteString -> Maybe ClusterNodesResponseSlotSpec
+            readSlotRange slotSpec = case BS.breakSubstring "-" slotSpec of
+                (_, "") -> Nothing
+                (leftPart, rightPart) -> ClusterNodesResponseSlotRange
+                    <$> readInteger leftPart
+                    <*> (readInteger $ BS.drop 1 rightPart)
+
+    decode r = Left r
+
+clusterNodes
+    :: (RedisCtx m f)
+    => m (f ClusterNodesResponse)
+clusterNodes = sendRequest $ ["CLUSTER", "NODES"]
+
+data ClusterSlotsResponse = ClusterSlotsResponse { clusterSlotsResponseEntries :: [ClusterSlotsResponseEntry] } deriving (Show)
+
+data ClusterSlotsNode = ClusterSlotsNode
+    { clusterSlotsNodeIP :: ByteString
+    , clusterSlotsNodePort :: Int
+    , clusterSlotsNodeID :: ByteString
+    } deriving (Show)
+
+data ClusterSlotsResponseEntry = ClusterSlotsResponseEntry 
+    { clusterSlotsResponseEntryStartSlot :: Int
+    , clusterSlotsResponseEntryEndSlot :: Int
+    , clusterSlotsResponseEntryMaster :: ClusterSlotsNode
+    , clusterSlotsResponseEntryReplicas :: [ClusterSlotsNode]
+    } deriving (Show)
+
+instance RedisResult ClusterSlotsResponse where
+    decode (MultiBulk (Just bulkData)) = do
+        clusterSlotsResponseEntries <- mapM decode bulkData
+        return ClusterSlotsResponse{..}
+    decode a = Left a
+
+instance RedisResult ClusterSlotsResponseEntry where
+    decode (MultiBulk (Just 
+        ((Integer startSlot):(Integer endSlot):masterData:replicas))) = do
+            clusterSlotsResponseEntryMaster <- decode masterData
+            clusterSlotsResponseEntryReplicas <- mapM decode replicas 
+            let clusterSlotsResponseEntryStartSlot = fromInteger startSlot
+            let clusterSlotsResponseEntryEndSlot = fromInteger endSlot
+            return ClusterSlotsResponseEntry{..}
+    decode a = Left a
+
+instance RedisResult ClusterSlotsNode where
+    decode (MultiBulk (Just ((Bulk (Just clusterSlotsNodeIP)):(Integer port):(Bulk (Just clusterSlotsNodeID)):_))) = Right ClusterSlotsNode{..}
+        where clusterSlotsNodePort = fromInteger port
+    decode a = Left a
+    
+
+clusterSlots
+    :: (RedisCtx m f)
+    => m (f ClusterSlotsResponse)
+clusterSlots = sendRequest $ ["CLUSTER", "SLOTS"]
+
+clusterSetSlotImporting 
+    :: (RedisCtx m f)
+    => Integer
+    -> ByteString
+    -> m (f Status)
+clusterSetSlotImporting slot sourceNodeId = sendRequest $ ["CLUSTER", "SETSLOT", (encode slot), "IMPORTING", sourceNodeId]
+
+clusterSetSlotMigrating 
+    :: (RedisCtx m f)
+    => Integer
+    -> ByteString
+    -> m (f Status)
+clusterSetSlotMigrating slot destinationNodeId = sendRequest $ ["CLUSTER", "SETSLOT", (encode slot), "MIGRATING", destinationNodeId]
+
+clusterSetSlotStable
+    :: (RedisCtx m f)
+    => Integer
+    -> m (f Status)
+clusterSetSlotStable slot = sendRequest $ ["CLUSTER", "SETSLOT", "STABLE", (encode slot)]
+
+clusterSetSlotNode
+    :: (RedisCtx m f)
+    => Integer
+    -> ByteString
+    -> m (f Status)
+clusterSetSlotNode slot node = sendRequest ["CLUSTER", "SETSLOT", (encode slot), "NODE", node]
+
+clusterGetKeysInSlot
+    :: (RedisCtx m f)
+    => Integer
+    -> Integer
+    -> m (f [ByteString])
+clusterGetKeysInSlot slot count = sendRequest ["CLUSTER", "GETKEYSINSLOT", (encode slot), (encode count)]

--- a/src/Database/Redis/ProtocolPipelining.hs
+++ b/src/Database/Redis/ProtocolPipelining.hs
@@ -16,7 +16,7 @@
 --
 module Database.Redis.ProtocolPipelining (
   Connection,
-  connect, enableTLS, beginReceiving, disconnect, request, send, recv, flush,
+  connect, enableTLS, beginReceiving, disconnect, request, send, recv, flush, fromCtx
 ) where
 
 import           Prelude
@@ -42,6 +42,10 @@ data Connection = Conn
     --   'connReplies' and 'connPending'.
     --   length connPending  - pendingCount = length connReplies
   }
+
+
+fromCtx :: CC.ConnectionContext -> IO Connection
+fromCtx ctx = Conn ctx <$> newIORef [] <*> newIORef [] <*> newIORef 0
 
 
 connect :: NS.HostName -> CC.PortID -> Maybe Int -> IO Connection

--- a/src/Database/Redis/PubSub.hs
+++ b/src/Database/Redis/PubSub.hs
@@ -33,7 +33,10 @@ import Data.ByteString.Char8 (ByteString)
 import Data.List (foldl')
 import Data.Maybe (isJust)
 import Data.Pool
+#if MIN_VERSION_base(4,13,0)
+#else
 import Data.Semigroup (Semigroup(..))
+#endif
 import qualified Data.HashMap.Strict as HM
 import qualified Database.Redis.Core as Core
 import qualified Database.Redis.Connection as Connection

--- a/src/Database/Redis/PubSub.hs
+++ b/src/Database/Redis/PubSub.hs
@@ -596,7 +596,7 @@ pubSubForever (Connection.NonClusteredConnection pool) ctrl onInitialLoad = with
           (Right (Left err)) -> throwIO err
           (Left (Left err)) -> throwIO err
           _ -> return ()  -- should never happen, since threads exit only with an error
-pubSubForever (Connection.ClusteredConnection _) _ _ = undefined
+pubSubForever (Connection.ClusteredConnection _ _) _ _ = undefined
 
 
 ------------------------------------------------------------------------------

--- a/src/Database/Redis/Transactions.hs
+++ b/src/Database/Redis/Transactions.hs
@@ -3,7 +3,7 @@
     GeneralizedNewtypeDeriving #-}
 
 module Database.Redis.Transactions (
-    watch, unwatch, multiExec,
+    watch, unwatch, multiExec, multiExecWithHash,
     Queued(), TxResult(..), RedisTx(),
 ) where
 
@@ -134,3 +134,27 @@ multi = sendRequest ["MULTI"]
 
 exec :: Redis Reply
 exec = either id id <$> sendRequest ["EXEC"]
+
+--------------
+
+multiExecWithHash :: ByteString -> RedisTx (Queued a) -> Redis (TxResult a)
+multiExecWithHash h rtx = do
+    -- We don't need to catch exceptions and call DISCARD. The pool will close
+    -- the connection anyway.
+    _        <- multiWithHash h
+    Queued f <- runRedisTx rtx
+    r        <- execWithHash h
+    case r of
+        MultiBulk rs ->
+
+            return $ maybe
+                TxAborted
+                (either (TxError . show) TxSuccess . f . fromList)
+                rs
+        _ -> error $ "hedis: EXEC returned " ++ show r
+
+multiWithHash :: ByteString -> Redis (Either Reply Status)
+multiWithHash h = sendRequest ["MULTI", h]
+
+execWithHash :: ByteString -> Redis Reply
+execWithHash h = either id id <$> sendRequest ["EXEC", h]

--- a/src/Database/Redis/URL.hs
+++ b/src/Database/Redis/URL.hs
@@ -8,7 +8,10 @@ import Control.Applicative ((<$>))
 #endif
 import Control.Error.Util (note)
 import Control.Monad (guard)
+#if MIN_VERSION_base(4,13,0)
+#else
 import Data.Monoid ((<>))
+#endif
 import Database.Redis.Connection (ConnectInfo(..), defaultConnectInfo)
 import qualified Database.Redis.ConnectionContext as CC
 import Network.HTTP.Base

--- a/src/Database/Redis/URL.hs
+++ b/src/Database/Redis/URL.hs
@@ -9,8 +9,8 @@ import Control.Applicative ((<$>))
 import Control.Error.Util (note)
 import Control.Monad (guard)
 import Data.Monoid ((<>))
-import Database.Redis.Core (ConnectInfo(..), defaultConnectInfo)
-import Database.Redis.ProtocolPipelining
+import Database.Redis.Connection (ConnectInfo(..), defaultConnectInfo)
+import qualified Database.Redis.ConnectionContext as CC
 import Network.HTTP.Base
 import Network.URI (parseURI, uriPath, uriScheme)
 import Text.Read (readMaybe)
@@ -57,7 +57,7 @@ parseConnectInfo url = do
         { connectHost = if null h
             then connectHost defaultConnectInfo
             else h
-        , connectPort = maybe (connectPort defaultConnectInfo) (PortNumber . fromIntegral) (port uriAuth)
+        , connectPort = maybe (connectPort defaultConnectInfo) (CC.PortNumber . fromIntegral) (port uriAuth)
         , connectAuth = C8.pack <$> password uriAuth
         , connectDatabase = db
         }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,6 @@
-resolver: lts-13.21
+resolver: lts-15.15
 packages:
-- '.'
-extra-deps:
-  - crc16-0.1.0
+  - '.'
 flags:
   hedis:
     dev: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,7 @@ resolver: lts-13.21
 packages:
 - '.'
 extra-deps:
+  - crc16-0.1.0
 flags:
   hedis:
     dev: true


### PR DESCRIPTION
I've been working on implementing the client aspects of clustered Redis on behalf of Juspay. This is a first attempt, it's a proof of concept so it's not at all complete, but I wanted to get feedback from the community to check we're on the right path.

The main limitations at the moment are:

- It only handles commands where the first argument is a key
- It doesn't do any kind of pipelining.
- It isn't threadsafe
- It doesn't do any kind of connection pooling

None of these are in principle hard to fix, but I wanted to make sure that the general approach worked.

There were a few changes I had to make:

- Moved the `ConnectionContext` abstraction into it's own module `Database.Redis.ConnectionContext` so it could be shared between clustered and non clustered connections
- Moved the `Connection` abstraction from `Core` into it's own module. This was necessary to break a dependency loop. Setting up a connection requires a few commands to be defined (e.g `AUTH` or `PING` or `CLUSTER SLOTS`). However, commands are defined in terms of `sendRequest`, which is in `Core`. This had been handled by defining the few commands necessary for setting up a connection in `Core`, this seemed unwieldy with the addition of cluster connections as I needed to add a fair amount of extra commands which would have been in `Core`, so I moved the connection setup code to `Databse.Redis.Connection`, which depends on `Core` and `Commands`.
- Added a new variant for the `RedisEnv` data type called `ClusteredEnv`, this carries around an `IORef` of a map from hashslots to node connections (which I've called a `ShardMap`) and an action to refresh the shard map. This is passed in to the code in `Database.Redis.Cluster` which uses it to handle `MOVED` redirections.
- Added a new variant for a `ClusteredConnection` to the `Connection` data type. This is necessary so that the `runRedis` function (which takes a `Connection` as it's argument) can figure out what kind of environment to run the `Redis` monad in).
- Added the `Database.Redis.Cluster` module. This is where most of the interesting stuff happens, more detail on this to follow.

The entry point to the new functionality is in the new definition of `sendRequest`, which now looks like this:

```haskell
sendRequest :: (RedisCtx m f, RedisResult a)
    => [B.ByteString] -> m (f a)
sendRequest req = do
    r' <- liftRedis $ Redis $ do
        env <- ask
        case env of 
            NonClusteredEnv{..} -> do
                r <- liftIO $ PP.request envConn (renderRequest req)
                setLastReply r
                return r
            ClusteredEnv{..} -> liftIO $ Cluster.request currentShardMap refreshAction req
    returnDecode r'
```

Here we can see that the function examines the environment it's running in and dispatches the request differently depending on whether it's in a `ClusteredEnv`, or `NonClusteredEnv`. The `refreshAction` and `currentShardMap` are carried around in the `Database.Redis.Connection.ClusteredConnection` and passed in to the Redis environment as part of `Database.Redis.Connection.runRedis`. So we can see that the meat of the implementation is in `Cluster.request`, which looks like this:

```haskell
request :: IOR.IORef ShardMap -> (() -> IO ShardMap) -> [B.ByteString] -> IO Reply
request shardMapRef refreshShardMap requestData = do
    shardMap <- IOR.readIORef shardMapRef
    let maybeNode = nodeForCommand shardMap requestData
    case maybeNode of
        Nothing -> throwIO $ MissingNodeException requestData
        Just node -> do
            resp <- requestNode node (renderRequest requestData)
            case resp of
                (Error errString) | B.isPrefixOf "MOVED" errString -> do
                    newShardMap <- refreshShardMap ()
                    IOR.writeIORef shardMapRef newShardMap
                    request shardMapRef refreshShardMap requestData
                (askingRedirection -> Just (host, port)) -> do
                    let maybeAskNode = nodeWithHostAndPort shardMap host port
                    case maybeAskNode of
                        Just askNode -> do
                            _ <- requestNode askNode (renderRequest ["ASKING"])
                            requestNode askNode (renderRequest requestData)
                        Nothing -> do
                            newShardMap <- refreshShardMap ()
                            IOR.writeIORef shardMapRef newShardMap
                            request shardMapRef refreshShardMap requestData
                _ -> return resp
```

You can see here that the basic clustering logic is implemented, it uses `nodeForCommand` to find the node it should send a request to, then dispatches the request to that node. It handles `MOVED` redirection by refreshing the shardmap and then rerunning the request, and it handles `ASK` redirection by looking up the required node and issueing an `ASKING` command to it directly prior to rerunning the command against it.

## How can I play with this?

I have a little test project you can play with [here](https://github.com/alexjg/hedis-cluster-test)

## What remains to be done

This is just a proof of concept, in particular these are the things I think I will need to fix for this to be complete:

- At the moment the `nodeForCommand` function only really handles commands where the first argument is a key, it will need to be fleshed out to handle all the commands redis cluster implements. This will include commands where the command is sent to every shard and the results aggregated.
- Connection pooling of some kind will need to be implemented. I am unsure as to what structure this should take, we can either have a pool of a map of connections to each shard (`Pool (Map HashSlot Shard)`), or the map of connections to each node can have a connection pool as it's value (`Map HashSlot (Pool Shard)`)
- The implementation needs to be threadsafe
- There is no pipelining, pipelining in a clustered environment cannot reuse the pipelining implementation from the non clustered implementation as far as I can see. The problem is that pipelining in the non clustered environment is done by queueing up requests in the buffer of the `Handle` associated with the connection. In a clustered context we need to be able to move commands to a different connection when we receive a `MOVED` or `ASK` redirection, so we need an explicit data structure for the pipeline. This explicit data structure would most likely also be usable as the implementation of the non clustered connection.
- In the interests of quickly getting to a rough implementation I've added a dependency on the `crc16` library, however, this library is small and not in the stackage snapshots, so it probably makes sense to vendor it in to this project


I would appreciate any feedback on the approach and it's suitability for merging when complete.