### PR TITLE
Add Eq instance to PortID

### DIFF
--- a/src/Database/Redis/ProtocolPipelining.hs
+++ b/src/Database/Redis/ProtocolPipelining.hs
@@ -44,7 +44,7 @@ import           Database.Redis.Protocol
 
 data PortID = PortNumber NS.PortNumber
             | UnixSocket String
-            deriving Show
+            deriving (Eq, Show)
 
 data ConnectionContext = NormalHandle Handle | TLSContext TLS.Context
 


### PR DESCRIPTION
Originally, Hedis re-exported the `PortID` type from `Network`, and it derived `Eq` as well as `Show`.  The `Network` module was deprecated in `network 2.7.0.0` and then removed in `network 3.0.0.0`.  Hedis was updated to just use `PortNumber` (from `Network.Socket`), removing support for Unix sockets.  A `PortID` type was then added to Hedis in order to restore support for Unix sockets in [commit 9c218f1b504206d644f9ee65b9d603a7e9418076](https://github.com/informatikr/hedis/commit/9c218f1b504206d644f9ee65b9d603a7e9418076).  The new type does not derive `Eq`, but I think that the `Eq` instance was just forgotten.  I use the hostname and port to identify connections during failover, so it would be convenient to have an `Eq` instance.