### PR TITLE
Make withConnect friendly to transformer stack

### DIFF
--- a/hedis.cabal
+++ b/hedis.cabal
@@ -142,6 +142,7 @@ test-suite hedis-test
 test-suite doctest
     type: exitcode-stdio-1.0
     main-is: DocTest.hs
+    ghc-options: -O0 -rtsopts
     build-depends:
         base == 4.*,
         doctest

--- a/hedis.cabal
+++ b/hedis.cabal
@@ -73,6 +73,7 @@ library
                     base >= 4.8 && < 5,
                     bytestring >= 0.9,
                     bytestring-lexing >= 0.5,
+                    exceptions,
                     unordered-containers,
                     text,
                     deepseq,

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env sh
+set -e
+
+echo "**These tests assume there is a redis server running on port 6379**"
 
 # The -M argument limits heap size for 'testConstantSpacePipelining'.
-cabal-dev test --test-options="+RTS -M3m"
+cabal exec cabal test doctest
+cabal test hedis-test --test-options="+RTS -M10m"
 
 echo "------------------"
 echo "hlint suggestions:"


### PR DESCRIPTION
withConnect has an embedded IO (i.e. `-> (a -> IO b) ->`) which is famously annoying for monad stacks.  We can generalize this really easily though using MonadMask from the exceptions package and lifting the connect/disconnect calls.