### PR TITLE
Publicly expose ConnectTimeout exception

### DIFF
--- a/src/Database/Redis.hs
+++ b/src/Database/Redis.hs
@@ -178,7 +178,8 @@ module Database.Redis (
 
     -- * Low-Level Command API
     sendRequest,
-    Reply(..),Status(..),RedisResult(..),ConnectionLostException(..),
+    Reply(..), Status(..), RedisResult(..), ConnectionLostException(..),
+    ConnectTimeout(..)
     
     -- |[Solution to Exercise]
     --
@@ -196,7 +197,7 @@ import Database.Redis.Core
 import Database.Redis.PubSub
 import Database.Redis.Protocol
 import Database.Redis.ProtocolPipelining
-    (PortID(..), ConnectionLostException(..))
+    (PortID(..), ConnectionLostException(..), ConnectTimeout(..))
 import Database.Redis.Transactions
 import Database.Redis.Types
 import Database.Redis.URL

--- a/src/Database/Redis/ProtocolPipelining.hs
+++ b/src/Database/Redis/ProtocolPipelining.hs
@@ -20,6 +20,7 @@ module Database.Redis.ProtocolPipelining (
   Connection,
   connect, enableTLS, beginReceiving, disconnect, request, send, recv, flush,
   ConnectionLostException(..),
+  ConnectTimeout(..),
   PortID(..)
 ) where
 


### PR DESCRIPTION
The `ConnectTimeout` exception can be thrown, however is not exported, and not be specifically caught from the public API. This can happen during for example a `checkedConnect`.

This PR exposes the `ConnectTimeout` exception.