### PR TITLE
Improved documentation for EVALSHA

### DIFF
--- a/src/Database/Redis/ManualCommands.hs
+++ b/src/Database/Redis/ManualCommands.hs
@@ -360,9 +360,11 @@ eval script keys args =
   where
     numkeys = toInteger (length keys)
 
+-- | Works like 'eval', but sends the SHA1 hash of the script instead of the script itself.
+-- Fails if the server does not recognise the hash, in which case, 'eval' should be used instead.
 evalsha
     :: (RedisCtx m f, RedisResult a)
-    => ByteString -- ^ script
+    => ByteString -- ^ base16-encoded sha1 hash of the script
     -> [ByteString] -- ^ keys
     -> [ByteString] -- ^ args
     -> m (f a)


### PR DESCRIPTION
This was confusing me because the existing documentation suggested the first argument was the script itself, but the docs indicate that argument should contain the Base16-encoded SHA1 hash of the script.

I have a little wrapper function which accepts the script itself, and performs the encoding, but you might not like to add something like `cryptonite` as a dependency here?

See https://redis.io/commands/eval#bandwidth-and-evalsha