### PR TITLE
remove invalid tests for Redis Cluster

### DIFF
--- a/test/ClusterMain.hs
+++ b/test/ClusterMain.hs
@@ -32,8 +32,7 @@ testsServer =
     [testBgrewriteaof, testFlushall, testSlowlog, testDebugObject]
 
 testsConnection :: [Test]
-testsConnection = [ testConnectAuthUnexpected, testConnectDb
-                  , testConnectDbUnexisting, testEcho, testPing
+testsConnection = [ testConnectAuthUnexpected, testEcho, testPing
                   ]
 
 testsKeys :: [Test]


### PR DESCRIPTION
Since Redis Cluster doesn't support the SELECT command, `testConnectDb` and `testConnectDbUnexisting` are not suitable for `ClusterMain.hs` .

Actually, these tests use `defaultConnectInfo` internally and try to connect to the default Redis server instead of Redis Cluster working on port 7000.
