### PR TITLE
Support GHC 9

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,12 @@
+packages:
+    ./
+
+source-repository-package
+    type: git
+    location: https://github.com/parsonsmatt/hs-memory
+    tag: 21e8720739b45dbee4faa1470db243ec9f487e44
+
+source-repository-package
+    type: git
+    location: https://github.com/amesgen/cryptonite
+    tag: c5b2630ac396ad2d14ee1ed5d216907acaf2e79e

--- a/src/Database/Redis/Transactions.hs
+++ b/src/Database/Redis/Transactions.hs
@@ -41,7 +41,7 @@ instance RedisCtx RedisTx Queued where
         -- future index in EXEC result list
         i <- get
         put (i+1)
-        return $ Queued (decode . (!i))
+        return $ Queued (decode . (! i))
 
 -- |A 'Queued' value represents the result of a command inside a transaction. It
 --  is a proxy object for the /actual/ result, which will only be available


### PR DESCRIPTION
Closes #170 

GHC 9 made parsing for a few symbols like `#` and `!` more strict. Previously, `!i` would parse as an expression if the `BangPatterns` extension was not enabled, and fail with a pattern parse error if it was. GHC 9 makes it consistent by failing to parse regardless of whether or not the extension is on.

Depends on https://github.com/vincenthz/hs-memory/issues/84 and https://github.com/haskell-crypto/cryptonite/pull/338 as documented by the `cabal.project` file.