### PR TITLE
Make SREM safer using `Data.List.NonEmpty`

### DIFF
--- a/codegen/GenCmds.hs
+++ b/codegen/GenCmds.hs
@@ -243,8 +243,10 @@ unimplementedCmds =
 
 exportList :: [Cmd] -> Builder
 exportList cmds =
-    mconcat . map exportGroup . groupBy ((==) `on` cmdGroup) $
-        sortBy (comparing cmdGroup) cmds
+    (mconcat . map exportGroup . groupBy ((==) `on` cmdGroup) $
+        sortBy (comparing cmdGroup) cmds)
+    `mappend`
+    manualExports
   where
     exportGroup group = mconcat
         [ newline
@@ -276,6 +278,23 @@ exportList cmds =
         "server"       -> "Server"
         "scripting"    -> "Scripting"
         _              -> error $ "untranslated group: " ++ cmdGroup
+
+    manualExports = mconcat $ map (\exprt -> fromString exprt `mappend` fromString ",\n")
+        [ "ClusterNodesResponse(..)"
+        , "ClusterNodesResponseEntry(..)"
+        , "ClusterNodesResponseSlotSpec(..)"
+        , "clusterNodes"
+        , "ClusterSlotsResponse(..)"
+        , "ClusterSlotsResponseEntry(..)"
+        , "ClusterSlotsNode(..)"
+        , "clusterSlots"
+        , "clusterSetSlotNode"
+        , "clusterSetSlotStable"
+        , "clusterSetSlotImporting"
+        , "clusterSetSlotMigrating"
+        , "clusterGetKeysInSlot"
+        , "command"
+        ]
 
 exportCmdNames :: Cmd -> Builder
 exportCmdNames Cmd{..} = types `mappend` functions
@@ -337,7 +356,7 @@ imprts = mconcat $ flip map moduls (\modul ->
              , "Data.ByteString (ByteString)"
              , "Database.Redis.ManualCommands"
              , "Database.Redis.Types"
-             , "Database.Redis.Core"
+             , "Database.Redis.Core (sendRequest, RedisCtx)"
              ]
 
 blackListed :: Cmd -> Bool


### PR DESCRIPTION
We had an error recently at runtime from passing `srem` the empty list `[]`. The `members` argument of `SREM` is actually non-optional - at least one value must be supplied. So it makes sense to generate a signature which uses a type that would catch the use of the empty list at compile-time, like the type in `Data.List.NonEmpty`.

This modifies the codegen to generate signatures and code using `NonEmpty` for every `multiple` argument of a command which isn't `optional`. Whether or not this is correct is unclear to me - this forbids some valid commands, like `SCRIPT EXISTS` with zero arguments. It's probable that there's some mistakes in the `commands.json` that need to be corrected so that this codegen can be more discerning.

This also adds some changes into the codegen that were introduced by #157 - that PR manually modified the file produced by the codegen in a way that meant the changes were lost when re-generating.