### PR TITLE
Expose RedisArg class to better support low-level sendRequest calls

### DIFF
--- a/src/Database/Redis.hs
+++ b/src/Database/Redis.hs
@@ -178,7 +178,7 @@ module Database.Redis (
 
     -- * Low-Level Command API
     sendRequest,
-    Reply(..), Status(..), RedisResult(..), ConnectionLostException(..),
+    Reply(..), Status(..), RedisArg(..), RedisResult(..), ConnectionLostException(..),
     ConnectTimeout(..),
 
     -- |[Solution to Exercise]


### PR DESCRIPTION
Make calling `sendRequest` a little easier by allowing to re-use hedis' `RedisArg` class. 