### PR TITLE
Record StrictData in other-extensions

### DIFF
--- a/hedis.cabal
+++ b/hedis.cabal
@@ -108,6 +108,7 @@ library
                     Database.Redis.ManualCommands,
                     Database.Redis.URL,
                     Database.Redis.ConnectionContext
+  other-extensions: StrictData
 
 benchmark hedis-benchmark
     default-language: Haskell2010


### PR DESCRIPTION
This tells Cabal not to attempt building with GHC < 8.

Fixes #177.