### PR TITLE
Document that UnixSocket ignores connectHost

### DIFF
--- a/src/Database/Redis/Connection.hs
+++ b/src/Database/Redis/Connection.hs
@@ -60,6 +60,7 @@ data Connection
 --
 data ConnectInfo = ConnInfo
     { connectHost           :: NS.HostName
+    -- ^ Ignored when 'connectPort' is a 'UnixSocket'
     , connectPort           :: CC.PortID
     , connectAuth           :: Maybe B.ByteString
     -- ^ When the server is protected by a password, set 'connectAuth' to 'Just'


### PR DESCRIPTION
Related to #188, in lieu of a breaking API change.