### PR TITLE
`mtl-2.3.1` compatibility

### DIFF
--- a/src/Database/Redis/Sentinel.hs
+++ b/src/Database/Redis/Sentinel.hs
@@ -46,6 +46,7 @@ import           Control.Exception     (Exception, IOException, evaluate, throwI
 import           Control.Monad
 import           Control.Monad.Catch   (Handler (..), MonadCatch, catches, throwM)
 import           Control.Monad.Except
+import           Control.Monad.IO.Class(MonadIO(liftIO))
 import           Data.ByteString       (ByteString)
 import qualified Data.ByteString       as BS
 import qualified Data.ByteString.Char8 as BS8


### PR DESCRIPTION
The upcoming `mtl-2.3.1` release will not re-export `MonadIO(liftIO)` from
unrelated modules. So let's add an additional (backwards compatible) import.
This keeps `hedis` working, even with the latest `mtl` release (which is currently not compatible).

Tested using the following `cabal.project`:

```
packages: .

constraints: mtl==2.3.1
```
