### PR TITLE
Require resource-pool >= 0.2.2

### DIFF
--- a/hedis.cabal
+++ b/hedis.cabal
@@ -82,7 +82,7 @@ library
                     deepseq,
                     mtl >= 2,
                     network >= 2 && < 3.2,
-                    resource-pool >= 0.2,
+                    resource-pool >= 0.2.2,
                     stm,
                     time,
                     tls >= 1.3,


### PR DESCRIPTION
`Data.Pool.destroyAllResources` is not available earlier.

As a Hackage trustee I made appropriate revisions.