### PR TITLE
Support mtl 2.3

### DIFF
--- a/src/Database/Redis/Sentinel.hs
+++ b/src/Database/Redis/Sentinel.hs
@@ -44,6 +44,7 @@ module Database.Redis.Sentinel
 import           Control.Concurrent
 import           Control.Exception     (Exception, IOException, evaluate, throwIO)
 import           Control.Monad
+import           Control.Monad.IO.Class
 import           Control.Monad.Catch   (Handler (..), MonadCatch, catches, throwM)
 import           Control.Monad.Except
 import           Data.ByteString       (ByteString)


### PR DESCRIPTION
Explicitly import Control.Monad.IO.Class as it's no longer re-exported by mtl modules.

I've checked that this builds