### PR TITLE
Add Redis 7.0 compatibility 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,9 @@
 
 ## 0.16
 
+- Extended Redis 6 and 7 support.
+  - add xgroupCreate, xgroupCreateConsumer, xgroupSetId.
+  
 Breaking changes:
 - **xpendingDetail** instead of 'Maybe ByteString' for a consumer name the method
 receives XPendingOpts structure that can take number of milliseconds and consumer name.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,15 @@
 # Changelog for Hedis
 
+## 0.16
+
+Breaking changes:
+- **xpendingDetail** instead of 'Maybe ByteString' for a consumer name the method
+receives XPendingOpts structure that can take number of milliseconds and consumer name.
+In order to preserve an old behavior code should be rewritten as:
+  xpendingDetails s g f l t Nothing -> xpendingSummary s g f l t defaultXPendingDetailOpts
+  xpendingDetails s g f l t (Just c) -> xpendingSummary s g f l t defaultXPendingDetailOpts{xPeedingDetailConsumer=Just c)
+- **xpendingSummary** no longer accepts consumer arguments as it was done in violation to spec and methodd never worked this way
+
 ## 0.15.2
 
 * PR #189. Document that UnixSocket ignores connectHost

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,15 +3,24 @@
 ## 0.16
 
 - Extended Redis 6 and 7 support.
-  - add xgroupCreate, xgroupCreateConsumer, xgroupSetId.
+  - add xgroupCreate, xgroupCreateConsumer, xgroupSetId;
+  - added support of the message trimming by message;
+  - add support for count parameter for approximate trimming.
   
 Breaking changes:
+
 - **xpendingDetail** instead of 'Maybe ByteString' for a consumer name the method
 receives XPendingOpts structure that can take number of milliseconds and consumer name.
 In order to preserve an old behavior code should be rewritten as:
   xpendingDetails s g f l t Nothing -> xpendingSummary s g f l t defaultXPendingDetailOpts
   xpendingDetails s g f l t (Just c) -> xpendingSummary s g f l t defaultXPendingDetailOpts{xPeedingDetailConsumer=Just c)
 - **xpendingSummary** no longer accepts consumer arguments as it was done in violation to spec and methodd never worked this way
+- **XTrimOpts** type changed, because previous type didn't hold library invariants now instead of a simple ADT XTrimOpts is data that defines strategy of trimming and type, exact or approximate. Here is a conversion table:
+  NoArg -> is not representable,
+   In xaddOpts options use Nothing instead;
+   In xtrim using NoArgs as a bug.
+  Maxlen n -> TrimOpts{trimOptsStrategy=TrimMaxlen n, trimOptsType=TrimExact};
+  MaxlenApprox n -> TrimOpts{trumOptsStrategy=TrimMaxlen n, trimOptsType=TrimApprox Nothing};
 
 ## 0.15.2
 

--- a/hedis.cabal
+++ b/hedis.cabal
@@ -152,6 +152,32 @@ test-suite hedis-test
     if flag(dev)
       ghc-prof-options: -auto-all
 
+test-suite redis7
+    default-language: Haskell2010
+    type: exitcode-stdio-1.0
+    hs-source-dirs: test
+    main-is: MainRedis7.hs
+    other-modules: PubSubTest
+                   Tests
+    build-depends:
+        base == 4.*,
+        bytestring >= 0.10,
+        hedis,
+        HUnit,
+        async,
+        stm,
+        text,
+        mtl == 2.*,
+        test-framework,
+        test-framework-hunit,
+        time
+    -- We use -O0 here, since GHC takes *very* long to compile so many constants
+    ghc-options: -O0 -Wall -rtsopts -fno-warn-unused-do-bind
+    if flag(dev)
+      ghc-options: -Werror
+    if flag(dev)
+      ghc-prof-options: -auto-all
+
 test-suite hedis-test-cluster
     default-language: Haskell2010
     type: exitcode-stdio-1.0

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -230,8 +230,14 @@ defaultXreadOpts,
 XReadResponse(..),
 StreamsRecord(..),
 TrimOpts(..),
-xadd, -- |Add a value to a stream (<https://redis.io/commands/xadd>). Since Redis 5.0.0
-xaddOpts, -- |Add a value to a stream (<https://redis.io/commands/xadd>). The Redis command @XADD@ is split up into 'xadd', 'xaddOpts'. Since Redis 5.0.0
+xadd,
+xaddOpts, 
+XAddOpts(..),
+defaultXAddOpts,
+TrimStrategy(..),
+TrimType(..),
+TrimOpts(..),
+trimOpts,
 xread, -- |Read values from a stream (<https://redis.io/commands/xread>). The Redis command @XREAD@ is split up into 'xread', 'xreadOpts'. Since Redis 5.0.0
 xreadOpts, -- |Read values from a stream (<https://redis.io/commands/xread>). The Redis command @XREAD@ is split up into 'xread', 'xreadOpts'. Since Redis 5.0.0
 xreadGroup, -- |Read values from a stream as part of a consumer group (https://redis.io/commands/xreadgroup). The redis command @XREADGROUP@ is split up into 'xreadGroup' and 'xreadGroupOpts'. Since Redis 5.0.0

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -159,6 +159,7 @@ ZaddOpts(..),
 defaultZaddOpts,
 zadd, -- |Add one or more members to a sorted set, or update its score if it already exists (<http://redis.io/commands/zadd>). The Redis command @ZADD@ is split up into 'zadd', 'zaddOpts'. Since Redis 1.2.0
 zaddOpts, -- |Add one or more members to a sorted set, or update its score if it already exists (<http://redis.io/commands/zadd>). The Redis command @ZADD@ is split up into 'zadd', 'zaddOpts'. Since Redis 1.2.0
+SizeCondition(..),
 zcard, -- |Get the number of members in a sorted set (<http://redis.io/commands/zcard>). Since Redis 1.2.0
 zcount, -- |Count the members in a sorted set with scores within the given values (<http://redis.io/commands/zcount>). Since Redis 2.0.0
 zincrby, -- |Increment the score of a member in a sorted set (<http://redis.io/commands/zincrby>). Since Redis 1.2.0
@@ -216,13 +217,16 @@ msetnx, -- |Set multiple keys to multiple values, only if none of the keys exist
 psetex, -- |Set the value and expiration in milliseconds of a key (<http://redis.io/commands/psetex>). Since Redis 2.6.0
 Condition(..),
 SetOpts(..),
-set, -- |Set the string value of a key (<http://redis.io/commands/set>). The Redis command @SET@ is split up into 'set', 'setOpts'. Since Redis 1.0.0
-setOpts, -- |Set the string value of a key (<http://redis.io/commands/set>). The Redis command @SET@ is split up into 'set', 'setOpts'. Since Redis 1.0.0
+set, -- |Set the string value of a key (<http://redis.io/commands/set>). The Redis command @SET@ is split up into 'set', 'setOpts', 'setGet', 'setGetOpts'. Since Redis 1.0.0
+setOpts, -- |Set the string value of a key (<http://redis.io/commands/set>). The Redis command @SET@ is split up into 'set', 'setOpts', 'setGet', 'setGetOpts'. Since Redis 1.0.0
+setGet, -- |Set the string value of a key (<http://redis.io/commands/set>). The Redis command @SET@ is split up into 'set', 'setOpts', 'setGet', 'setGetOpts'. Since Redis 1.0.0
+setGetOpts, -- |Set the string value of a key (<http://redis.io/commands/set>). The Redis command @SET@ is split up into 'set', 'setOpts', 'setGet', 'setGetOpts'. Since Redis 1.0.0
 setbit, -- |Sets or clears the bit at offset in the string value stored at key (<http://redis.io/commands/setbit>). Since Redis 2.2.0
 setex, -- |Set the value and expiration of a key (<http://redis.io/commands/setex>). Since Redis 2.0.0
 setnx, -- |Set the value of a key, only if the key does not exist (<http://redis.io/commands/setnx>). Since Redis 1.0.0
 setrange, -- |Overwrite part of a string at key starting at the specified offset (<http://redis.io/commands/setrange>). Since Redis 2.2.0
 strlen, -- |Get the length of the value stored in a key (<http://redis.io/commands/strlen>). Since Redis 2.2.0
+
 
 -- ** Streams
 XReadOpts(..),

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -237,10 +237,30 @@ xreadOpts, -- |Read values from a stream (<https://redis.io/commands/xread>). Th
 xreadGroup, -- |Read values from a stream as part of a consumer group (https://redis.io/commands/xreadgroup). The redis command @XREADGROUP@ is split up into 'xreadGroup' and 'xreadGroupOpts'. Since Redis 5.0.0
 xreadGroupOpts, -- |Read values from a stream as part of a consumer group (https://redis.io/commands/xreadgroup). The redis command @XREADGROUP@ is split up into 'xreadGroup' and 'xreadGroupOpts'. Since Redis 5.0.0
 xack, -- |Acknowledge receipt of a message as part of a consumer group. Since Redis 5.0.0
-xgroupCreate, -- |Create a consumer group. The redis command @XGROUP@ is split up into 'xgroupCreate', 'xgroupSetId', 'xgroupDestroy', and 'xgroupDelConsumer'. Since Redis 5.0.0
-xgroupSetId, -- |Set the id for a consumer group. The redis command @XGROUP@ is split up into 'xgroupCreate', 'xgroupSetId', 'xgroupDestroy', and 'xgroupDelConsumer'. Since Redis 5.0.0
-xgroupDestroy, -- |Destroy a consumer group. The redis command @XGROUP@ is split up into 'xgroupCreate', 'xgroupSetId', 'xgroupDestroy', and 'xgroupDelConsumer'. Since Redis 5.0.0
-xgroupDelConsumer, -- |Delete a consumer. The redis command @XGROUP@ is split up into 'xgroupCreate', 'xgroupSetId', 'xgroupDestroy', and 'xgroupDelConsumer'. Since Redis 5.0.0
+
+-- *** XGROUP CREATE
+-- $xgroupCreate
+xgroupCreate,
+xgroupCreateOpts,
+XGroupCreateOpts(..),
+defaultXGroupCreateOpts,
+
+-- *** XGROUP CREATECONSUMER
+xgroupCreateConsumer,
+
+-- *** XGROUP SETID
+-- $xgroupSetId
+xgroupSetId,
+xgroupSetIdOpts,
+XGroupSetIdOpts(..),
+defaultXGroupSetIdOpts,
+
+-- *** XGROUP DESTROY
+xgroupDestroy,
+
+-- *** XGROUP DELCONSUMER
+xgroupDelConsumer,
+
 xrange, -- |Read values from a stream within a range (https://redis.io/commands/xrange). Since Redis 5.0.0
 xrevRange, -- |Read values from a stream within a range in reverse order (https://redis.io/commands/xrevrange). Since Redis 5.0.0
 xlen, -- |Get the number of entries in a stream (https://redis.io/commands/xlen). Since Redis 5.0.0
@@ -1126,4 +1146,10 @@ sismember key member = sendRequest (["SISMEMBER"] ++ [encode key] ++ [encode mem
 -- All commands are available since Redis 7.0
 
 -- $xpending
--- The Redis @XPENDING@ command is split into 'xpendingSummary' and 'xpendingDetail'. 
+-- The Redis @XPENDING@ command is split into 'xpendingSummary' and 'xpendingDetail'.
+
+-- $xgroupCreate
+-- Create a consumer group. The redis command @XGROUP CREATE@ is split up into 'xgroupCreate', 'xgroupCreateOpts'.
+
+-- $xgroupSetId
+-- Sets last delivered ID for a consumer group. The redis command @XGROUP SETID@ is split up into 'xgroupSetId' and 'xgroupSetIdOpts' methods.

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -244,10 +244,16 @@ xgroupDelConsumer, -- |Delete a consumer. The redis command @XGROUP@ is split up
 xrange, -- |Read values from a stream within a range (https://redis.io/commands/xrange). Since Redis 5.0.0
 xrevRange, -- |Read values from a stream within a range in reverse order (https://redis.io/commands/xrevrange). Since Redis 5.0.0
 xlen, -- |Get the number of entries in a stream (https://redis.io/commands/xlen). Since Redis 5.0.0
+
+-- *** XPENDING
+-- $xpending
+xpendingSummary,
 XPendingSummaryResponse(..),
-xpendingSummary, -- |Get information about pending messages (https://redis.io/commands/xpending). The Redis @XPENDING@ command is split into 'xpendingSummary' and 'xpendingDetail'. Since Redis 5.0.0
+XPendingDetailOpts(..),
+defaultXPendingDetailOpts,
 XPendingDetailRecord(..),
-xpendingDetail, -- |Get detailed information about pending messages (https://redis.io/commands/xpending). The Redis @XPENDING@ command is split into 'xpendingSummary' and 'xpendingDetail'. Since Redis 5.0.0
+xpendingDetail,
+
 XClaimOpts(..),
 defaultXClaimOpts,
 xclaim, -- |Change ownership of some messages to the given consumer, returning the updated messages. The Redis @XCLAIM@ command is split into 'xclaim' and 'xclaimJustIds'. Since Redis 5.0.0
@@ -1118,3 +1124,6 @@ sismember key member = sendRequest (["SISMEMBER"] ++ [encode key] ++ [encode mem
 -- `xautoclaimJustIdsOpt` functions.
 --
 -- All commands are available since Redis 7.0
+
+-- $xpending
+-- The Redis @XPENDING@ command is split into 'xpendingSummary' and 'xpendingDetail'. 

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -252,6 +252,17 @@ XClaimOpts(..),
 defaultXClaimOpts,
 xclaim, -- |Change ownership of some messages to the given consumer, returning the updated messages. The Redis @XCLAIM@ command is split into 'xclaim' and 'xclaimJustIds'. Since Redis 5.0.0
 xclaimJustIds, -- |Change ownership of some messages to the given consumer, returning only the changed message IDs. The Redis @XCLAIM@ command is split into 'xclaim' and 'xclaimJustIds'. Since Redis 5.0.0
+
+-- *** Autoclaim
+-- $autoclaim
+xautoclaim,
+xautoclaimOpts,
+XAutoclaimOpts(..),
+XAutoclaimStreamsResult,
+XAutoclaimResult(..),
+xautoclaimJustIds,
+xautoclaimJustIdsOpts,
+XAutoclaimJustIdsResult,
 XInfoConsumersResponse(..),
 xinfoConsumers, -- |Get info about consumers in a group. The Redis command @XINFO@ is split into 'xinfoConsumers', 'xinfoGroups', and 'xinfoStream'. Since Redis 5.0.0
 XInfoGroupsResponse(..),
@@ -1093,3 +1104,17 @@ sismember
     -> ByteString -- ^ member
     -> m (f Bool)
 sismember key member = sendRequest (["SISMEMBER"] ++ [encode key] ++ [encode member] )
+
+-- $autoclaim
+--
+-- Family of the commands related to the autoclaim command in redis, they provide an
+-- ability to claim messages that are not processed for a long time.
+--
+-- Transfers ownership of pending stream entries that match
+-- the specified criteria. The message should be pending for more than \<min-idle-time\>
+-- milliseconds and ID should be greater than \<start\>.
+--
+-- Redis @xautoclaim@ command is split info `xautoclaim`, `xautoclaimOpts`, `xautoclaimJustIds`
+-- `xautoclaimJustIdsOpt` functions.
+--
+-- All commands are available since Redis 7.0

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -21,6 +21,7 @@ tests conn = map ($conn) $ concat
     , [testQuit]
     ]
 
+
 testsServer :: [Test]
 testsServer =
     [testServer, testBgrewriteaof, testFlushall, testInfo, testConfig

--- a/test/MainRedis7.hs
+++ b/test/MainRedis7.hs
@@ -1,0 +1,13 @@
+module Main (main) where
+
+import qualified Test.Framework as Test
+import Database.Redis
+import Tests
+
+main :: IO ()
+main = do
+    conn <- connect defaultConnectInfo
+    Test.defaultMain (tests conn)
+
+tests :: Connection -> [Test.Test]
+tests conn = map ($ conn) $ [testXCreateGroup7, testXpending7, testXAutoClaim7, testQuit]

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -688,6 +688,12 @@ testXReadGroup = testCase "XGROUP */xreadgroup/xack" $ do
     xgroupDelConsumer "somestream" "somegroup" "consumer1" >>=? 0
     xgroupDestroy "somestream" "somegroup" >>=? True
 
+testXCreateGroup7 ::Test
+testXCreateGroup7 = testCase "XGROUP CREATE" $ do
+    xgroupCreateOpts "somestream" "somegroup" "0" XGroupCreateOpts {xGroupCreateMkStream    = True,
+                                                                    xGroupCreateEntriesRead = Just "1234"} >>=? Ok
+    return ()
+
 testXRange ::Test
 testXRange = testCase "xrange/xrevrange" $ do
     xadd "somestream" "121" [("key1", "value1")]

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -472,6 +472,50 @@ testTransaction = testCase "transaction" $ do
         return $ (,) <$> foo <*> bar
     assert $ foobar == TxSuccess (Just "foo", Just "bar")
 
+testSet7 :: Test
+testSet7 = testCase "Set" $ do
+    set "hello" "hi" >>=? Ok
+    setOpts "hello" "hi" SetOpts{
+        setSeconds           = Nothing,
+        setMilliseconds      = Nothing,
+        setUnixSeconds       = Just 2000,
+        setUnixMilliseconds  = Nothing,
+        setCondition         = Nothing,
+        setKeepTTL           = False
+    } >>=? Ok
+    setOpts "hello" "hi" SetOpts{
+        setSeconds           = Nothing,
+        setMilliseconds      = Nothing,
+        setUnixSeconds       = Nothing,
+        setUnixMilliseconds  = Just 20000,
+        setCondition         = Nothing,
+        setKeepTTL           = False
+    } >>=? Ok
+    setOpts "hello" "hi" SetOpts{
+        setSeconds           = Nothing,
+        setMilliseconds      = Nothing,
+        setUnixSeconds       = Nothing,
+        setUnixMilliseconds  = Nothing,
+        setCondition         = Nothing,
+        setKeepTTL           = True
+    } >>=? Ok
+    setGet "hello" "henlo" >>=? "hi"
+    setGetOpts "hello" "henlo2" SetOpts{
+        setSeconds           = Nothing,
+        setMilliseconds      = Nothing,
+        setUnixSeconds       = Nothing,
+        setUnixMilliseconds  = Nothing,
+        setCondition         = Just Nx,
+        setKeepTTL           = False
+    } >>=? "henlo"
+    return ()
+
+testZAdd7 :: Test
+testZAdd7 = testCase "ZADD" $ do
+    zadd "set" [(42, "2")] >>=? 1
+    zaddOpts "set" [(44, "6")] (defaultZaddOpts {zaddSizeCondition = Just CGT}) >>=? 1
+    zaddOpts "set" [(46, "7")] (defaultZaddOpts {zaddSizeCondition = Just CLT}) >>=? 1
+    return ()
 
 ------------------------------------------------------------------------------
 -- Scripting


### PR DESCRIPTION
In this MR we add a Redis 7 support for XINFO commands. And improve test-suite.
All changes are backwards compatible.