### PR TITLE
Add ability to use ACL

### DIFF
--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -3,7 +3,14 @@
 module Database.Redis.Commands (
 
 -- ** Connection
-auth, -- |Authenticate to the server (<http://redis.io/commands/auth>). Since Redis 1.0.0
+
+-- *** auth
+-- $auth
+auth, 
+authOpts,
+AuthOpts(..),
+defaultAuthOpts,
+-- *** Other commands
 echo, -- |Echo the given string (<http://redis.io/commands/echo>). Since Redis 1.0.0
 ping, -- |Ping the server (<http://redis.io/commands/ping>). Since Redis 1.0.0
 quit, -- |Close the connection (<http://redis.io/commands/quit>). Since Redis 1.0.0
@@ -1167,3 +1174,7 @@ sismember key member = sendRequest (["SISMEMBER"] ++ [encode key] ++ [encode mem
 
 -- $xgroupSetId
 -- Sets last delivered ID for a consumer group. The redis command @XGROUP SETID@ is split up into 'xgroupSetId' and 'xgroupSetIdOpts' methods.
+
+
+-- $auth
+-- Authenticate to the server (<http://redis.io/commands/auth>). Since Redis 1.0.0

--- a/src/Database/Redis/URL.hs
+++ b/src/Database/Redis/URL.hs
@@ -15,6 +15,8 @@ import Database.Redis.Connection (ConnectInfo(..), defaultConnectInfo)
 import qualified Database.Redis.ConnectionContext as CC
 import Network.HTTP.Base
 import Network.URI (parseURI, uriPath, uriScheme)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 import Text.Read (readMaybe)
 
 import qualified Data.ByteString.Char8 as C8
@@ -24,7 +26,7 @@ import qualified Data.ByteString.Char8 as C8
 -- Username is ignored, path is used to specify the database:
 --
 -- >>> parseConnectInfo "redis://username:password@host:42/2"
--- Right (ConnInfo {connectHost = "host", connectPort = PortNumber 42, connectAuth = Just "password", connectDatabase = 2, connectMaxConnections = 50, connectMaxIdleTime = 30s, connectTimeout = Nothing, connectTLSParams = Nothing})
+-- Right (ConnInfo {connectHost = "host", connectPort = PortNumber 42, connectAuth = Just "password",connectUsername=Just "username", connectDatabase = 2, connectMaxConnections = 50, connectMaxIdleTime = 30s, connectTimeout = Nothing, connectTLSParams = Nothing})
 --
 -- >>> parseConnectInfo "redis://username:password@host:42/db"
 -- Left "Invalid port: db"
@@ -38,7 +40,7 @@ import qualified Data.ByteString.Char8 as C8
 -- @'defaultConnectInfo'@:
 --
 -- >>> parseConnectInfo "redis://"
--- Right (ConnInfo {connectHost = "localhost", connectPort = PortNumber 6379, connectAuth = Nothing, connectDatabase = 0, connectMaxConnections = 50, connectMaxIdleTime = 30s, connectTimeout = Nothing, connectTLSParams = Nothing})
+-- Right (ConnInfo {connectHost = "localhost", connectPort = PortNumber 6379, connectAuth = Nothing, connectUsername=Nothing, connectDatabase = 0, connectMaxConnections = 50, connectMaxIdleTime = 30s, connectTimeout = Nothing, connectTLSParams = Nothing})
 --
 parseConnectInfo :: String -> Either String ConnectInfo
 parseConnectInfo url = do
@@ -61,5 +63,6 @@ parseConnectInfo url = do
             else h
         , connectPort = maybe (connectPort defaultConnectInfo) (CC.PortNumber . fromIntegral) (port uriAuth)
         , connectAuth = C8.pack <$> password uriAuth
+        , connectUsername = T.encodeUtf8 . T.pack <$> user uriAuth
         , connectDatabase = db
         }

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -31,7 +31,7 @@ testsServer =
     ,testSlowlog, testDebugObject]
 
 testsConnection :: [Test]
-testsConnection = [ testConnectAuth, testConnectAuthUnexpected, testConnectDb
+testsConnection = [ testConnectAuth, testConnectAuthUnexpected, testConnectAuthAcl,testConnectDb
                   , testConnectDbUnexisting, testEcho, testPing, testSelect ]
 
 testsKeys :: [Test]


### PR DESCRIPTION
Introduce auth option that support passing username:
   authOpts

Extend parseUrl function to parse username as well.

Fixes #199 