### PR TITLE
feat: Granular subscription tracking

### DIFF
--- a/hedis.cabal
+++ b/hedis.cabal
@@ -90,7 +90,8 @@ library
                     HTTP,
                     errors,
                     network-uri,
-                    unliftio-core
+                    unliftio-core,
+                    hashable
   if !impl(ghc >= 8.0)
     build-depends:
       semigroups >= 0.11 && < 0.19


### PR DESCRIPTION
This commit makes it so that:

* `{add,remove}ChannelsAndWait` only wait for the channels they care about, not every channel.
* You can check which channels are waiting for subscription acknowledgements via `pending{Pattern,}Channels`

I think it should work on GHC>=7.4 (because of `ConstraintKinds`), but admittedly I've only tested it with GHC 9.4.4.
If more compatibility is needed just let me know, and I'll add more CPP instead.