### PR TITLE
Introducing hooks

### DIFF
--- a/hedis.cabal
+++ b/hedis.cabal
@@ -108,7 +108,8 @@ library
                     Database.Redis.Commands,
                     Database.Redis.ManualCommands,
                     Database.Redis.URL,
-                    Database.Redis.ConnectionContext
+                    Database.Redis.ConnectionContext,
+                    Database.Redis.Hooks
   other-extensions: StrictData
 
 benchmark hedis-benchmark
@@ -199,6 +200,24 @@ test-suite hedis-test-cluster
         time
     -- We use -O0 here, since GHC takes *very* long to compile so many constants
     ghc-options: -O0 -Wall -rtsopts -fno-warn-unused-do-bind
+    if flag(dev)
+      ghc-options: -Werror
+    if flag(dev)
+      ghc-prof-options: -auto-all
+
+test-suite hedis-test-hooks
+    default-language: Haskell2010
+    type: exitcode-stdio-1.0
+    hs-source-dirs: test
+    main-is: MainHooks.hs
+    build-depends:
+        base == 4.*,
+        hedis,
+        HUnit,
+        test-framework,
+        test-framework-hunit
+    -- We use -O0 here, since GHC takes *very* long to compile so many constants
+    ghc-options: -O0 -Wall -rtsopts -fno-warn-unused-do-bind -Wunused-packages
     if flag(dev)
       ghc-options: -Werror
     if flag(dev)

--- a/src/Database/Redis.hs
+++ b/src/Database/Redis.hs
@@ -176,6 +176,9 @@ module Database.Redis (
     -- * Pub\/Sub
     module Database.Redis.PubSub,
 
+    -- * Hooks
+    Hooks(..), SendRequestHook, SendPubSubHook, CallbackHook, SendHook, ReceiveHook, defaultHooks,
+
     -- * Low-Level Command API
     sendRequest,
     Reply(..), Status(..), RedisArg(..), RedisResult(..), ConnectionLostException(..),

--- a/src/Database/Redis/Connection.hs
+++ b/src/Database/Redis/Connection.hs
@@ -31,7 +31,7 @@ import qualified Network.Socket as NS
 import qualified Data.HashMap.Strict as HM
 
 import qualified Database.Redis.ProtocolPipelining as PP
-import Database.Redis.Core(Redis, runRedisInternal, runRedisClusteredInternal)
+import Database.Redis.Core(Redis, Hooks, runRedisInternal, runRedisClusteredInternal, defaultHooks)
 import Database.Redis.Protocol(Reply(..))
 import Database.Redis.Cluster(ShardMap(..), Node, Shard(..))
 import qualified Database.Redis.Cluster as Cluster
@@ -97,6 +97,7 @@ data ConnectInfo = ConnInfo
     --   get connected in this interval of time.
     , connectTLSParams      :: Maybe ClientParams
     -- ^ Optional TLS parameters. TLS will be enabled if this is provided.
+    , connectHooks          :: Hooks
     } deriving Show
 
 data ConnectError = ConnectAuthError Reply
@@ -117,6 +118,7 @@ instance Exception ConnectError
 --  connectMaxIdleTime    = 30              -- Keep open for 30 seconds
 --  connectTimeout        = Nothing         -- Don't add timeout logic
 --  connectTLSParams      = Nothing         -- Do not use TLS
+--  connectHooks          = defaultHooks    -- Do nothing
 -- @
 --
 defaultConnectInfo :: ConnectInfo
@@ -130,13 +132,14 @@ defaultConnectInfo = ConnInfo
     , connectMaxIdleTime    = 30
     , connectTimeout        = Nothing
     , connectTLSParams      = Nothing
+    , connectHooks          = defaultHooks
     }
 
 createConnection :: ConnectInfo -> IO PP.Connection
 createConnection ConnInfo{..} = do
     let timeoutOptUs =
           round . (1000000 *) <$> connectTimeout
-    conn <- PP.connect connectHost connectPort timeoutOptUs
+    conn <- PP.connectWithHooks connectHost connectPort timeoutOptUs connectHooks
     conn' <- case connectTLSParams of
                Nothing -> return conn
                Just tlsParams -> PP.enableTLS tlsParams conn
@@ -231,9 +234,9 @@ connectCluster bootstrapConnInfo = do
         Left e -> throwIO $ ClusterConnectError e
         Right infos -> do
 #if MIN_VERSION_resource_pool(0,3,0)
-            pool <- newPool (defaultPoolConfig (Cluster.connect infos shardMapVar Nothing) Cluster.disconnect (realToFrac $ connectMaxIdleTime bootstrapConnInfo) (connectMaxConnections bootstrapConnInfo))
+            pool <- newPool (defaultPoolConfig (Cluster.connect infos shardMapVar Nothing $ connectHooks bootstrapConnInfo) Cluster.disconnect (realToFrac $ connectMaxIdleTime bootstrapConnInfo) (connectMaxConnections bootstrapConnInfo))
 #else
-            pool <- createPool (Cluster.connect infos shardMapVar Nothing) Cluster.disconnect 1 (connectMaxIdleTime bootstrapConnInfo) (connectMaxConnections bootstrapConnInfo)
+            pool <- createPool (Cluster.connect infos shardMapVar Nothing $ connectHooks bootstrapConnInfo) Cluster.disconnect 1 (connectMaxIdleTime bootstrapConnInfo) (connectMaxConnections bootstrapConnInfo)
 #endif
             return $ ClusteredConnection shardMapVar pool
 
@@ -255,7 +258,7 @@ shardMapFromClusterSlotsResponse ClusterSlotsResponse{..} = ShardMap <$> foldr m
             Cluster.Node clusterSlotsNodeID role hostname (toEnum clusterSlotsNodePort)
 
 refreshShardMap :: Cluster.Connection -> IO ShardMap
-refreshShardMap (Cluster.Connection nodeConns _ _ _) = do
+refreshShardMap (Cluster.Connection nodeConns _ _ _ _) = do
     let (Cluster.NodeConnection ctx _ _) = head $ HM.elems nodeConns
     pipelineConn <- PP.fromCtx ctx
     _ <- PP.beginReceiving pipelineConn

--- a/src/Database/Redis/Hooks.hs
+++ b/src/Database/Redis/Hooks.hs
@@ -1,0 +1,44 @@
+module Database.Redis.Hooks where
+
+import Data.ByteString (ByteString)
+import Database.Redis.Protocol (Reply)
+import {-# SOURCE #-} Database.Redis.PubSub (Message, PubSub)
+
+data Hooks =
+  Hooks
+    { sendRequestHook :: SendRequestHook
+    , sendPubSubHook :: SendPubSubHook
+    , callbackHook :: CallbackHook
+    , sendHook :: SendHook
+    , receiveHook :: ReceiveHook
+    }
+
+-- | A hook for sending commands to the server and receiving replys from the server.
+type SendRequestHook = ([ByteString] -> IO Reply) -> [ByteString] -> IO Reply
+
+-- | A hook for sending pub/sub messages to the server.
+type SendPubSubHook = ([ByteString] -> IO ()) -> [ByteString] -> IO ()
+
+-- | A hook for invoking callbacks with pub/sub messages.
+type CallbackHook = (Message -> IO PubSub) -> Message -> IO PubSub
+
+-- | A hook for just sending raw data to the server.
+type SendHook = (ByteString -> IO ()) -> ByteString -> IO ()
+
+-- | A hook for receiving raw data from the server.
+type ReceiveHook = IO Reply -> IO Reply
+
+-- | The default hooks.
+-- Every hook is the identity function.
+defaultHooks :: Hooks
+defaultHooks =
+  Hooks
+    { sendRequestHook = id
+    , sendPubSubHook = id
+    , callbackHook = id
+    , sendHook = id
+    , receiveHook = id
+    }
+
+instance Show Hooks where
+  show _ = "Hooks {sendRequestHook = _, sendPubSubHook = _, callbackHook = _, sendHook = _, receiveHook = _}"

--- a/src/Database/Redis/ProtocolPipelining.hs
+++ b/src/Database/Redis/ProtocolPipelining.hs
@@ -17,7 +17,7 @@
 --
 module Database.Redis.ProtocolPipelining (
   Connection,
-  connect, enableTLS, beginReceiving, disconnect, request, send, recv, flush, fromCtx
+  connect, connectWithHooks, enableTLS, beginReceiving, disconnect, request, send, recv, flush, fromCtx, hooks
 ) where
 
 import           Prelude
@@ -31,6 +31,7 @@ import           System.IO.Unsafe
 
 import           Database.Redis.Protocol
 import qualified Database.Redis.ConnectionContext as CC
+import           Database.Redis.Hooks
 
 data Connection = Conn
   { connCtx        :: CC.ConnectionContext -- ^ Connection socket-handle.
@@ -42,14 +43,18 @@ data Connection = Conn
     -- ^ Number of pending replies and thus the difference length between
     --   'connReplies' and 'connPending'.
     --   length connPending  - pendingCount = length connReplies
+  , hooks         :: Hooks
   }
 
 
 fromCtx :: CC.ConnectionContext -> IO Connection
-fromCtx ctx = Conn ctx <$> newIORef [] <*> newIORef [] <*> newIORef 0
+fromCtx ctx = Conn ctx <$> newIORef [] <*> newIORef [] <*> newIORef 0 <*> pure defaultHooks
 
 connect :: NS.HostName -> CC.PortID -> Maybe Int -> IO Connection
-connect hostName portId timeoutOpt = do
+connect hostName portId timeoutOpt = connectWithHooks hostName portId timeoutOpt defaultHooks
+
+connectWithHooks :: NS.HostName -> CC.PortID -> Maybe Int -> Hooks -> IO Connection
+connectWithHooks hostName portId timeoutOpt hooks = do
     connCtx <- CC.connect hostName portId timeoutOpt
     connReplies <- newIORef []
     connPending <- newIORef []
@@ -74,7 +79,7 @@ disconnect Conn{..} = CC.disconnect connCtx
 --  The 'Handle' is 'hFlush'ed when reading replies from the 'connCtx'.
 send :: Connection -> S.ByteString -> IO ()
 send Conn{..} s = do
-  CC.send connCtx s
+  sendHook hooks (CC.send connCtx) s
 
   -- Signal that we expect one more reply from Redis.
   n <- atomicModifyIORef' connPendingCnt $ \n -> let n' = n+1 in (n', n')
@@ -88,10 +93,11 @@ send Conn{..} s = do
 
 -- |Take a reply-thunk from the list of future replies.
 recv :: Connection -> IO Reply
-recv Conn{..} = do
-  (r:rs) <- readIORef connReplies
-  writeIORef connReplies rs
-  return r
+recv Conn{..} =
+  receiveHook hooks $ do
+    (r:rs) <- readIORef connReplies
+    writeIORef connReplies rs
+    return r
 
 -- | Flush the socket.  Normally, the socket is flushed in 'recv' (actually 'conGetReplies'), but
 -- for the multithreaded pub/sub code, the sending thread needs to explicitly flush the subscription

--- a/src/Database/Redis/PubSub.hs-boot
+++ b/src/Database/Redis/PubSub.hs-boot
@@ -1,0 +1,8 @@
+module Database.Redis.PubSub (
+    Message,
+    PubSub,
+) where
+
+data PubSub
+
+data Message

--- a/test/MainHooks.hs
+++ b/test/MainHooks.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import qualified Test.Framework.Providers.HUnit as Test (testCase)
+import qualified Test.Framework as Test
+import Database.Redis
+import Data.IORef
+import qualified Test.HUnit as HUnit
+import Control.Monad.IO.Class (MonadIO(liftIO))
+
+main :: IO ()
+main = Test.defaultMain [testSetGet]
+
+data Counts =
+    Counts 
+        { sendRequestCount :: Word
+        , sendPubSubCount :: Word
+        , callbackCount :: Word
+        , sendCount :: Word
+        , receiveCount :: Word
+        }
+    deriving (Show, Eq)
+
+testCase :: String -> Counts -> Redis () -> Test.Test
+testCase name expected r = Test.testCase name $ do
+    ref <- newIORef $ Counts 0 0 0 0 0
+    conn <- connect defaultConnectInfo {connectHooks = hooks ref}
+    t <- runRedis conn $ flushdb >>=? Ok >> r
+    actual <- readIORef ref
+    HUnit.assertEqual "count" expected actual
+    return t
+
+hooks :: IORef Counts -> Hooks
+hooks ref =
+    defaultHooks
+        { sendRequestHook = \f message -> do
+            modifyIORef ref $ \c -> c {sendRequestCount = succ $ sendRequestCount c}
+            f message
+        , sendPubSubHook = \f message -> do
+            modifyIORef ref $ \c -> c {sendPubSubCount = succ $ sendPubSubCount c}
+            f message
+        , callbackHook = \f message -> do
+            modifyIORef ref $ \c -> c {callbackCount = succ $ callbackCount c}
+            f message
+        , sendHook = \f message -> do
+            modifyIORef ref $ \c -> c {sendCount = succ $ sendCount c}
+            f message
+        , receiveHook = \m -> do
+            modifyIORef ref $ \c -> c {receiveCount = succ $ receiveCount c}
+            m
+        }
+
+(>>=?) :: (Eq a, Show a) => Redis (Either Reply a) -> a -> Redis ()
+redis >>=? expected = redis >>@? (expected HUnit.@=?)
+
+(>>@?) :: (Eq a, Show a) => Redis (Either Reply a) -> (a -> HUnit.Assertion) -> Redis ()
+redis >>@? predicate = do
+    a <- redis
+    liftIO $ case a of
+        Left reply -> HUnit.assertFailure $ "Redis error: " ++ show reply
+        Right actual -> predicate actual
+
+testSetGet :: Test.Test
+testSetGet =
+    testCase
+        "set/get"
+        (Counts 3 0 0 3 3) $ do
+    set "{same}key" "value"     >>=? Ok
+    get "{same}key"             >>=? Just "value"


### PR DESCRIPTION
This PR introduce hooks. These hooks hook sending requests and receiving responses.

# Motivation

I am implementing an instrumentation of OpenTelemetry for Hedis. First I wrapped the Hedis functions to record for tracing, but it cause a lot of type mismatch because the original client and the wrappers have different types of course. So I want to use hooks to avoid this inconvenience.


# Changes

- `ConnectInfo` has a new field `connectHooks`
- `Hooks` type is introduced

Currently there are five types of hooks:

- `sendRequest`
- `sendPubSub`
- `callback`
- `send`
- `receive`

`sendRequest` is called when a command is being sent. `sendPubSub` is called when a Pub/Sub message is being send. `callback` is called when a reaction to a Pub/Sub message is being called after receiving its message. `send` and `receive` are low-level hooks

# Notes

A WIP implementation of the instrumentation of OpenTelemetry for Hedis is https://github.com/herp-inc/hs-opentelemetry/pull/15/.

