### PR TITLE
Allow network-3.2

### DIFF
--- a/hedis.cabal
+++ b/hedis.cabal
@@ -81,7 +81,7 @@ library
                     text,
                     deepseq,
                     mtl >= 2,
-                    network >= 2 && < 3.2,
+                    network >= 2 && < 3.3,
                     resource-pool >= 0.2,
                     stm,
                     time,


### PR DESCRIPTION
Fix #225. Addresses

* https://github.com/commercialhaskell/stackage/issues/7381

Tested with

    cabal build -c 'network>=3.2' -w ghc-9.8.2
