### PR TITLE
Fix incorrect type of rpopCount

### DIFF
--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -1256,7 +1256,7 @@ rpop
 rpop key = sendRequest ["RPOP", encode key]
 
 -- |Remove and get the last element in a list (<http://redis.io/commands/rpop>).
---
+-- The reply will consist of up to count elements, depending on the list's length.
 -- Result will have no more than @N@ arguments.
 --
 -- Since Redis 1.0.0
@@ -1264,7 +1264,7 @@ rpopCount
     :: (RedisCtx m f)
     => ByteString -- ^ key
     -> Integer
-    -> m (f (Maybe ByteString))
+    -> m (f [ByteString])
 rpopCount key count = sendRequest (["RPOP",key, encode count] )
 
 -- |Rename a key (<http://redis.io/commands/rename>). Since Redis 1.0.0

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -11,7 +11,7 @@ main = do
     Test.defaultMain (tests conn)
 
 tests :: Connection -> [Test.Test]
-tests conn = map ($conn) $ concat
+tests conn = map ($ conn) $ concat
     [ testsMisc, testsKeys, testsStrings, [testHashes], testsLists, testsSets, [testHyperLogLog]
     , testsZSets, [testPubSub], [testTransaction], [testScripting]
     , testsConnection, testsClient, testsServer, [testScans, testSScan, testHScan, testZScan], [testZrangelex]

--- a/test/PubSubTest.hs
+++ b/test/PubSubTest.hs
@@ -6,7 +6,7 @@ import Control.Monad
 import Control.Concurrent.Async
 import Control.Exception
 import qualified Data.List
-import Data.Text hiding (show)
+import Data.Text (Text)
 import Data.Typeable
 import Data.ByteString
 import Control.Concurrent.STM

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -302,6 +302,12 @@ testLists = testCase "lists" $ do
     lrem "key" 0 "v2"             >>=? 1
     llen "key"                    >>=? 2
     ltrim "key" 0 1               >>=? Ok
+    del ("key" NE.:| [])
+    -- keys are pushed sequentially so this will result in a list with value1, value2, value3
+    lpush "key" ["value3", "value2", "value1"] >>=? 3
+    lpopCount "key" 2 >>=? ["value1", "value2"]
+    lpush "key" ["value2", "value1"] >>=? 3
+    rpopCount "key" 2 >>=? ["value3", "value2"]
 
 testBpop :: Test
 testBpop = testCase "blocking push/pop" $ do


### PR DESCRIPTION
rpopCount has the same type of rpop instead of returning a list. I had to make a few minor modifications to a few other modules to get this to build against 9.6.7