### PR TITLE
Introduce safer version of connection.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,25 @@
 
 Breaking changes:
 
+- **Connection** Fix connection API.
+
+  ```haskell
+  data PortID = PortNumber NS.PortNumber
+              | UnixSocket String
+              deriving (Eq, Show)
+  ```
+
+  And introduce instead `ConnectAddr`:
+
+  ```haskell
+  data ConnectAddr
+    = ConnectAddrHostPort NS.HostName NS.PortNumber
+    | ConnectAddrUnixSocket String
+    deriving (Eq, Show)
+  ```
+
+  It allow to remove a hack with ignored path.
+
 - **URI parsing** follows the redis client spec. Main changes:
 
   1. In `redis://password@host`, `password` is parsed as a password instead of a username.

--- a/src/Database/Redis.hs
+++ b/src/Database/Redis.hs
@@ -18,7 +18,7 @@ module Database.Redis (
     -- import Data.Default.Class (def)
     -- (Just certStore) <- readCertificateStore "azure-redis.crt"
     -- let tlsParams = (defaultParamsClient "foobar.redis.cache.windows.net" "") { clientSupported = def { supportedCiphers = ciphersuite_strong }, clientShared = def { sharedCAStore = certStore } }
-    -- let redisConnInfo = defaultConnectInfo { connectHost = "foobar.redis.cache.windows.net", connectPort = PortNumber 6380, connectTLSParams = Just tlsParams, connectAuth = Just "Foobar!" }
+    -- let redisConnInfo = defaultConnectInfo { connectAddr = ConnectAddrHostPort "foobar.redis.cache.windows.net" 6380, connectTLSParams = Just tlsParams, connectAuth = Just "Foobar!" }
     -- conn <- checkedConnect redisConnInfo
     -- @
     --
@@ -165,7 +165,7 @@ module Database.Redis (
     Connection, ConnectError(..), connect, checkedConnect,
     ClusterConnectError (..), connectCluster, checkedConnectCluster,
     disconnect, withConnect, withCheckedConnect,
-    ConnectInfo(..), defaultConnectInfo, parseConnectInfo, PortID(..),
+    ConnectInfo(..), defaultConnectInfo, parseConnectInfo, ConnectAddr(..),
 
     -- * Commands
     module Database.Redis.Commands,
@@ -212,7 +212,7 @@ import Database.Redis.Connection
     , Connection(..)
     , withConnect
     , withCheckedConnect)
-import Database.Redis.ConnectionContext(PortID(..), ConnectionLostException(..), ConnectTimeout(..))
+import Database.Redis.ConnectionContext(ConnectAddr(..), ConnectionLostException(..), ConnectTimeout(..))
 import Database.Redis.PubSub
 import Database.Redis.Protocol
 import Database.Redis.Transactions

--- a/src/Database/Redis/Cluster.hs
+++ b/src/Database/Redis/Cluster.hs
@@ -125,7 +125,7 @@ connectWith mUsername mPassword mTlsParams commandInfos shardMapVar timeoutOpt h
     connectNodes [] = return []
     connectNodes (z@(Node _ _ host port):ns) = do
         bracketOnError
-          (CC.connect host (CC.PortNumber $ toEnum port) timeoutOpt)
+          (CC.connect (CC.ConnectAddrHostPort host $ toEnum port) timeoutOpt)
           (CC.disconnect) $ \ctx0 -> do
             nodeConn <- connectNode z ctx0
             rest <- connectNodes ns

--- a/src/Database/Redis/Connection.hs
+++ b/src/Database/Redis/Connection.hs
@@ -15,7 +15,6 @@ import qualified Data.IntMap.Strict as IntMap
 import Data.Pool
 import qualified Data.Time as Time
 import Network.TLS (ClientParams)
-import qualified Network.Socket as NS
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
 
@@ -64,9 +63,7 @@ data Connection
 -- @
 --
 data ConnectInfo = ConnInfo
-    { connectHost           :: NS.HostName
-    -- ^ Ignored when 'connectPort' is a 'UnixSocket'
-    , connectPort           :: CC.PortID
+    { connectAddr           :: CC.ConnectAddr
     , connectAuth           :: Maybe B.ByteString
     -- ^ When the server is protected by a password, set 'connectAuth' to 'Just'
     --   the password. Each connection will then authenticate by the 'auth'
@@ -106,8 +103,7 @@ instance Exception ConnectError
 -- |Default information for connecting:
 --
 -- @
---  connectHost           = \"localhost\"
---  connectPort           = PortNumber 6379 -- Redis default port
+--  connectAddr           = ConnectAddrHostPort \"localhost\" 6379 -- Redis default port
 --  connectAuth           = Nothing         -- No password
 --  connectUsername       = Nothing         -- No user
 --  connectDatabase       = 0               -- SELECT database 0
@@ -122,8 +118,7 @@ instance Exception ConnectError
 --
 defaultConnectInfo :: ConnectInfo
 defaultConnectInfo = ConnInfo
-    { connectHost           = "localhost"
-    , connectPort           = CC.PortNumber 6379
+    { connectAddr           = CC.ConnectAddrHostPort "localhost" 6379
     , connectAuth           = Nothing
     , connectUsername       = Nothing
     , connectDatabase       = 0
@@ -140,7 +135,7 @@ createConnection :: ConnectInfo -> IO PP.Connection
 createConnection ConnInfo{..} = do
     let timeoutOptUs =
           round . (1000000 *) <$> connectTimeout
-    conn <- PP.connectWithHooks connectHost connectPort timeoutOptUs connectHooks
+    conn <- PP.connectWithHooks connectAddr timeoutOptUs connectHooks
     conn' <- case connectTLSParams of
                Nothing -> return conn
                Just tlsParams -> PP.enableTLS tlsParams conn

--- a/src/Database/Redis/ConnectionContext.hs
+++ b/src/Database/Redis/ConnectionContext.hs
@@ -6,7 +6,7 @@ module Database.Redis.ConnectionContext (
     ConnectionContext(..)
   , ConnectTimeout(..)
   , ConnectionLostException(..)
-  , PortID(..)
+  , ConnectAddr(..)
   , connect
   , disconnect
   , send
@@ -57,12 +57,13 @@ instance Exception ConnectTimeout
 data ConnectionLostException = ConnectionLost deriving Show
 instance Exception ConnectionLostException
 
-data PortID = PortNumber NS.PortNumber
-            | UnixSocket String
-            deriving (Eq, Show)
+data ConnectAddr
+  = ConnectAddrHostPort NS.HostName NS.PortNumber
+  | ConnectAddrUnixSocket String
+  deriving (Eq, Show)
 
-connect :: NS.HostName -> PortID -> Maybe Int -> IO ConnectionContext
-connect hostName portId timeoutOpt =
+connect :: ConnectAddr -> Maybe Int -> IO ConnectionContext
+connect connectAddr timeoutOpt =
   bracketOnError hConnect hClose $ \h -> do
     hSetBinaryMode h True
     return $ NormalHandle h
@@ -85,11 +86,11 @@ connect hostName portId timeoutOpt =
           void $ swapMVar mvar PhaseOpenSocket
           NS.socketToHandle sock ReadWriteMode
           where
-            createSock = case portId of
-              PortNumber portNumber -> do
+            createSock = case connectAddr of
+              ConnectAddrHostPort hostName portNumber -> do
                 addrInfo <- getHostAddrInfo hostName portNumber
                 connectSocket addrInfo
-              UnixSocket addr -> bracketOnError
+              ConnectAddrUnixSocket addr -> bracketOnError
                 (NS.socket NS.AF_UNIX NS.Stream NS.defaultProtocol)
                 NS.close
                 (\sock -> NS.connect sock (NS.SockAddrUnix addr) >> return sock)

--- a/src/Database/Redis/ProtocolPipelining.hs
+++ b/src/Database/Redis/ProtocolPipelining.hs
@@ -25,7 +25,6 @@ import           Control.Monad
 import qualified Scanner
 import qualified Data.ByteString as S
 import           Data.IORef
-import qualified Network.Socket as NS
 import qualified Network.TLS as TLS
 import           System.IO.Unsafe
 
@@ -50,12 +49,12 @@ data Connection = Conn
 fromCtx :: CC.ConnectionContext -> IO Connection
 fromCtx ctx = Conn ctx <$> newIORef [] <*> newIORef [] <*> newIORef 0 <*> pure defaultHooks
 
-connect :: NS.HostName -> CC.PortID -> Maybe Int -> IO Connection
-connect hostName portId timeoutOpt = connectWithHooks hostName portId timeoutOpt defaultHooks
+connect :: CC.ConnectAddr -> Maybe Int -> IO Connection
+connect connectAddr timeoutOpt = connectWithHooks connectAddr timeoutOpt defaultHooks
 
-connectWithHooks :: NS.HostName -> CC.PortID -> Maybe Int -> Hooks -> IO Connection
-connectWithHooks hostName portId timeoutOpt hooks = do
-    connCtx <- CC.connect hostName portId timeoutOpt
+connectWithHooks :: CC.ConnectAddr -> Maybe Int -> Hooks -> IO Connection
+connectWithHooks connectAddr timeoutOpt hooks = do
+    connCtx <- CC.connect connectAddr timeoutOpt
     connReplies <- newIORef []
     connPending <- newIORef []
     connPendingCnt <- newIORef 0

--- a/src/Database/Redis/Sentinel.hs
+++ b/src/Database/Redis/Sentinel.hs
@@ -14,7 +14,7 @@
 -- Example:
 --
 -- @
--- conn <- 'connect' 'SentinelConnectionInfo' (("localhost", PortNumber 26379) :| []) "mymaster" 'defaultConnectInfo'
+-- conn <- 'connect' 'SentinelConnectionInfo' (("localhost", 26379) :| []) "mymaster" 'defaultConnectInfo'
 --
 -- 'runRedis' conn $ do
 --   'set' "hello" "world"
@@ -54,7 +54,7 @@ import           Data.Foldable         (toList)
 import           Data.List             (delete)
 import           Data.List.NonEmpty    (NonEmpty (..))
 import           Data.Unique
-import           Network.Socket        (HostName)
+import qualified Network.Socket        as NS
 
 import           Database.Redis hiding (Connection, connect, runRedis)
 import qualified Database.Redis as Redis
@@ -105,7 +105,7 @@ runRedis (SentinelConnection connMVar) action = do
 
   where
     sameHost :: Redis.ConnectInfo -> Redis.ConnectInfo -> Bool
-    sameHost l r = connectHost l == connectHost r && connectPort l == connectPort r
+    sameHost l r = connectAddr l == connectAddr r
 
     setCheckSentinel preToken = modifyMVar_ connMVar $ \conn@SentinelConnection'{rcToken} ->
       if preToken == rcToken
@@ -147,13 +147,12 @@ updateMaster sci@SentinelConnectInfo{..} = do
           )
         Right () -> throwIO $ NoSentinels connectSentinels
   where
-    trySentinel :: HostName -> PortID -> ExceptT (Redis.ConnectInfo, (HostName, PortID)) IO ()
+    trySentinel :: NS.HostName -> NS.PortNumber -> ExceptT (Redis.ConnectInfo, (NS.HostName, NS.PortNumber)) IO ()
     trySentinel sentinelHost sentinelPort = do
       -- bang to ensure exceptions from runRedis get thrown immediately.
       !replyE <- liftIO $ do
         !sentinelConn <- Redis.connect $ Redis.defaultConnectInfo
-            { connectHost = sentinelHost
-            , connectPort = sentinelPort
+            { connectAddr = ConnectAddrHostPort sentinelHost sentinelPort
             , connectMaxConnections = 1
             }
         Redis.runRedis sentinelConn $ sendRequest
@@ -163,12 +162,14 @@ updateMaster sci@SentinelConnectInfo{..} = do
         Right [host, port] ->
           throwError
             ( connectBaseInfo
-              { connectHost = BS8.unpack host
-              , connectPort =
-                  maybe
-                    (PortNumber 26379)
-                    (PortNumber . fromIntegral . fst)
+              { connectAddr =
+                  ConnectAddrHostPort
+                    (BS8.unpack host)
+                    (maybe
+                      26379
+                      (fromIntegral . fst)
                     $ BS8.readInt port
+                    )
               }
             , (sentinelHost, sentinelPort)
             )
@@ -202,19 +203,19 @@ data SentinelConnection'
 -- | Configuration of Sentinel hosts.
 data SentinelConnectInfo
   = SentinelConnectInfo
-      { connectSentinels  :: NonEmpty (HostName, PortID)
+      { connectSentinels  :: NonEmpty (NS.HostName, NS.PortNumber)
         -- ^ List of sentinels.
       , connectMasterName :: ByteString
         -- ^ Name of master to connect to.
       , connectBaseInfo   :: Redis.ConnectInfo
         -- ^ This is used to configure auth and other parameters for Redis connection,
-        -- but 'Redis.connectHost' and 'Redis.connectPort' are ignored.
+        -- but 'Redis.connectAddr' is ignored.
       }
   deriving (Show)
 
 -- | Exception thrown by "Database.Redis.Sentinel".
 data RedisSentinelException
-  = NoSentinels (NonEmpty (HostName, PortID))
+  = NoSentinels (NonEmpty (NS.HostName, NS.PortNumber))
     -- ^ Thrown if no sentinel can be reached.
   deriving (Show)
 

--- a/src/Database/Redis/URL.hs
+++ b/src/Database/Redis/URL.hs
@@ -35,10 +35,10 @@ import Text.Read (readMaybe)
 -- @
 --
 -- >>> parseConnectInfo "redis://username:password@host:42/2"
--- Right (ConnInfo {connectHost = "host", connectPort = PortNumber 42, connectAuth = Just "password", connectUsername = Just "username", connectDatabase = 2, connectMaxConnections = 50, connectNumStripes = Just 1, connectMaxIdleTime = 30s, connectTimeout = Nothing, connectTLSParams = Nothing, connectHooks = Hooks {...}, connectPoolLabel = ""})
+-- Right (ConnInfo {connectAddr = ConnectAddrHostPort "host" 42, connectAuth = Just "password", connectUsername = Just "username", connectDatabase = 2, connectMaxConnections = 50, connectNumStripes = Just 1, connectMaxIdleTime = 30s, connectTimeout = Nothing, connectTLSParams = Nothing, connectHooks = Hooks {...}, connectPoolLabel = ""})
 --
 -- >>> parseConnectInfo "redis://password@host:42/2"
--- Right (ConnInfo {connectHost = "host", connectPort = PortNumber 42, connectAuth = Just "password", connectUsername = Nothing, connectDatabase = 2, connectMaxConnections = 50, connectNumStripes = Just 1, connectMaxIdleTime = 30s, connectTimeout = Nothing, connectTLSParams = Nothing, connectHooks = Hooks {...}, connectPoolLabel = ""})
+-- Right (ConnInfo {connectAddr = ConnectAddrHostPort "host" 42, connectAuth = Just "password", connectUsername = Nothing, connectDatabase = 2, connectMaxConnections = 50, connectNumStripes = Just 1, connectMaxIdleTime = 30s, connectTimeout = Nothing, connectTLSParams = Nothing, connectHooks = Hooks {...}, connectPoolLabel = ""})
 --
 -- TLS-enabled Redis:
 --
@@ -53,7 +53,7 @@ import Text.Read (readMaybe)
 -- @
 --
 -- >>> parseConnectInfo "redis-socket://password@/tmp/redis.sock?database=2"
--- Right (ConnInfo {connectHost = "", connectPort = UnixSocket "/tmp/redis.sock", connectAuth = Just "password", connectUsername = Nothing, connectDatabase = 2, connectMaxConnections = 50, connectNumStripes = Just 1, connectMaxIdleTime = 30s, connectTimeout = Nothing, connectTLSParams = Nothing, connectHooks = Hooks {...}, connectPoolLabel = ""})
+-- Right (ConnInfo {connectAddr = ConnectAddrUnixSocket "/tmp/redis.sock", connectAuth = Just "password", connectUsername = Nothing, connectDatabase = 2, connectMaxConnections = 50, connectNumStripes = Just 1, connectMaxIdleTime = 30s, connectTimeout = Nothing, connectTLSParams = Nothing, connectHooks = Hooks {...}, connectPoolLabel = ""})
 --
 -- >>> parseConnectInfo "redis://username:password@host:42/db"
 -- Left "Invalid port: db"
@@ -67,7 +67,7 @@ import Text.Read (readMaybe)
 -- @'defaultConnectInfo'@:
 --
 -- >>> parseConnectInfo "rediss://"
--- Right (ConnInfo {connectHost = "localhost", connectPort = PortNumber 6379, connectAuth = Nothing, connectUsername = Nothing, connectDatabase = 0, connectMaxConnections = 50, connectNumStripes = Just 1, connectMaxIdleTime = 30s, connectTimeout = Nothing, connectTLSParams = Just (ClientParams ...), connectHooks = Hooks {...}, connectPoolLabel = ""})
+-- Right (ConnInfo {connectAddr = ConnectAddrHostPort "localhost" 6379, connectAuth = Nothing, connectUsername = Nothing, connectDatabase = 0, connectMaxConnections = 50, connectNumStripes = Just 1, connectMaxIdleTime = 30s, connectTimeout = Nothing, connectTLSParams = Just (ClientParams ...), connectHooks = Hooks {...}, connectPoolLabel = ""})
 --
 parseConnectInfo :: String -> Either String ConnectInfo
 parseConnectInfo url = do
@@ -93,7 +93,9 @@ parseConnectInfo url = do
               else note ("Invalid port: " <> dbNumPart) $ readMaybe dbNumPart
 
             let finalHost = if null h
-                    then connectHost defaultConnectInfo
+                    then case connectAddr defaultConnectInfo of
+                      CC.ConnectAddrHostPort defaultHost _ -> defaultHost
+                      CC.ConnectAddrUnixSocket _ -> "localhost"
                     else h
 
             let (finalUser, finalAuth) = case (T.pack <$> user uriAuth, T.pack <$> password uriAuth) of
@@ -102,8 +104,10 @@ parseConnectInfo url = do
                     (u, p) -> (u, p)
 
             return defaultConnectInfo
-                { connectHost = finalHost
-                , connectPort = maybe (connectPort defaultConnectInfo) (CC.PortNumber . fromIntegral) (port uriAuth)
+                { connectAddr =
+                    CC.ConnectAddrHostPort
+                      finalHost
+                      (maybe defaultPort fromIntegral (port uriAuth))
                 , connectAuth = T.encodeUtf8 <$> finalAuth
                 , connectUsername = T.encodeUtf8 <$> finalUser
                 , connectDatabase = db
@@ -111,6 +115,10 @@ parseConnectInfo url = do
                      False -> Nothing
                      True -> Just $ defaultParamsClient finalHost ""
                 }
+          where
+            defaultPort = case connectAddr defaultConnectInfo of
+              CC.ConnectAddrHostPort _ portNum -> portNum
+              CC.ConnectAddrUnixSocket _ -> 6379
 
         parseUnix :: URI -> Either String ConnectInfo
         parseUnix uri = do
@@ -122,8 +130,7 @@ parseConnectInfo url = do
                     Just dbNumPart ->
                         note "Invalid database" $ readMaybe @Integer . T.unpack $ T.decodeUtf8 dbNumPart
             return defaultConnectInfo
-                { connectHost = ""
-                , connectPort = CC.UnixSocket (mkPath auth)
+                { connectAddr = CC.ConnectAddrUnixSocket (mkPath auth)
                 , connectAuth = C8.pack <$> (user auth)
                 , connectDatabase = (db :: Integer)
                 }

--- a/test/ClusterMain.hs
+++ b/test/ClusterMain.hs
@@ -17,7 +17,7 @@ main = do
     -- spin up a cluster on this port using docker you can run:
     --
     --     docker run -e "IP=0.0.0.0" -p 7000-7010:7000-7010 grokzen/redis-cluster:5.0.6
-    conn <- connectCluster defaultConnectInfo { connectPort = PortNumber 16381 }
+    conn <- connectCluster defaultConnectInfo { connectAddr = ConnectAddrHostPort "localhost" 16381 }
     Test.defaultMain (tests "localhost" conn)
 
 tests :: String ->Connection -> [Test.Test]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -12,7 +12,7 @@ main = do
     host <- lookupEnv "REDIS_HOST" >>= \case
         Just host -> return host
         Nothing -> return "localhost"
-    conn <- connect defaultConnectInfo { connectHost = host }
+    conn <- connect defaultConnectInfo { connectAddr = ConnectAddrHostPort host 6379 }
     Test.defaultMain (tests host conn)
 
 tests :: String -> Connection -> [Test.Test]

--- a/test/MainRedis7.hs
+++ b/test/MainRedis7.hs
@@ -11,7 +11,7 @@ main = do
     host <- lookupEnv "REDIS_HOST" >>= \case
         Just host -> return host
         Nothing -> return "localhost"
-    conn <- connect defaultConnectInfo{ connectHost = host }
+    conn <- connect defaultConnectInfo{ connectAddr = ConnectAddrHostPort host 6379 }
     Test.defaultMain (tests conn)
 
 tests :: Connection -> [Test.Test]

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -576,7 +576,7 @@ testConnectAuth :: String ->Test
 testConnectAuth host = testCase "connect/auth" $ do
     configSet "requirepass" "pass" >>=? Ok
     liftIO $ do
-        c <- checkedConnect defaultConnectInfo { connectAuth = Just "pass", connectHost = host }
+        c <- checkedConnect defaultConnectInfo { connectAuth = Just "pass", connectAddr = ConnectAddrHostPort host 6379 }
         runRedis c (ping >>=? Pong)
     auth "pass"                    >>=? Ok
     configSet "requirepass" ""     >>=? Ok
@@ -587,7 +587,7 @@ testConnectAuthUnexpected host = testCase "connect/auth/unexpected" $ do
         res <- try $ void $ checkedConnect connInfo
         HUnit.assertEqual "" err res
 
-    where connInfo = defaultConnectInfo { connectAuth = Just "pass", connectHost = host }
+    where connInfo = defaultConnectInfo { connectAuth = Just "pass", connectAddr = ConnectAddrHostPort host 6379 }
           err = Left $ ConnectAuthError $
                   Error "ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?"
 
@@ -595,13 +595,13 @@ testConnectAuthUnexpected host = testCase "connect/auth/unexpected" $ do
 testConnectAuthAcl :: String -> Test
 testConnectAuthAcl host = testCase "connect/auth/acl" $ do
    liftIO $ do
-      c <- checkedConnect defaultConnectInfo { connectHost = host }
+      c <- checkedConnect defaultConnectInfo { connectAddr = ConnectAddrHostPort host 6379 }
       runRedis c $ sendRequest  ["ACL", "SETUSER", "test", "on", ">pass", "~*", "&*", "+@all"] >>=? Ok
    liftIO $ do
-      c <- checkedConnect defaultConnectInfo{connectAuth=Just "pass", connectUsername=Just "test", connectHost = host}
+      c <- checkedConnect defaultConnectInfo{connectAuth=Just "pass", connectUsername=Just "test", connectAddr = ConnectAddrHostPort host 6379}
       runRedis c (ping >>=? Pong)
    liftIO $ do
-      res <- try $ void $ checkedConnect defaultConnectInfo{connectAuth=Just "pass", connectUsername=Just "test1", connectHost = host}
+      res <- try $ void $ checkedConnect defaultConnectInfo{connectAuth=Just "pass", connectUsername=Just "test1", connectAddr = ConnectAddrHostPort host 6379}
       HUnit.assertEqual "" err res
    where
      err = Left $ ConnectAuthError $
@@ -611,7 +611,7 @@ testConnectDb :: String -> Test
 testConnectDb host = testCase "connect/db" $ do
     set "connect" "value" >>=? Ok
     liftIO $ void $ do
-        c <- checkedConnect defaultConnectInfo { connectDatabase = 1, connectHost = host }
+        c <- checkedConnect defaultConnectInfo { connectDatabase = 1, connectAddr = ConnectAddrHostPort host 6379 }
         runRedis c (get "connect" >>=? Nothing)
 
 testConnectDbUnexisting :: String -> Test
@@ -623,7 +623,7 @@ testConnectDbUnexisting host = testCase "connect/db/unexisting" $ do
           _ -> HUnit.assertFailure $
                   "Expected ConnectSelectError, got " ++ show res
 
-    where connInfo = defaultConnectInfo { connectDatabase = 100, connectHost = host }
+    where connInfo = defaultConnectInfo { connectDatabase = 100, connectAddr = ConnectAddrHostPort host 6379 }
 
 testEcho :: Test
 testEcho = testCase "echo" $
@@ -975,4 +975,3 @@ testXTrim = testCase "xtrim" $ do
     xadd "somestream" "125" [("key5", "value5")]
     xtrim "somestream" (trimOpts (TrimMaxlen 3) TrimExact) >>=? 2
     xtrim "somestream" (trimOpts (TrimMinId streamId) TrimExact) >>=? 1
-


### PR DESCRIPTION
Instead of

```haskell
data PortID = PortNumber NS.PortNumber
            | UnixSocket String
            deriving (Eq, Show)
```

Introduce instead `ConnectAddr`:

```haskell
data ConnectAddr
  = ConnectAddrHostPort NS.HostName NS.PortNumber
  | ConnectAddrUnixSocket String
  deriving (Eq, Show)
```