### PR TITLE
Upstream `runRedisNonBlocking`

### DIFF
--- a/src/Database/Redis.hs
+++ b/src/Database/Redis.hs
@@ -157,7 +157,7 @@ module Database.Redis (
     --
     
     -- * The Redis Monad
-    Redis(), runRedis,
+    Redis(), runRedis, runRedisNonBlocking,
     unRedis, reRedis,
     RedisCtx(..), MonadRedis(..),
 

--- a/src/Database/Redis/ManualCommands.hs
+++ b/src/Database/Redis/ManualCommands.hs
@@ -847,7 +847,7 @@ instance RedisResult StreamsRecord where
         return StreamsRecord{..}
         where
             decodeKeyValues :: [ByteString] -> [(ByteString, ByteString)]
-            decodeKeyValues bs = map (\[x,y] -> (x,y)) $ chunksOfTwo bs
+            decodeKeyValues bs = map (\xs -> (head xs, xs !! 1)) $ chunksOfTwo bs
             chunksOfTwo (x:y:rest) = [x,y]:chunksOfTwo rest
             chunksOfTwo _ = []
     decode a = Left a

--- a/src/Database/Redis/ProtocolPipelining.hs
+++ b/src/Database/Redis/ProtocolPipelining.hs
@@ -129,7 +129,7 @@ connGetReplies conn@Conn{..} = go S.empty (SingleLine "previous of first")
           Scanner.Done rest' r -> do
             -- r is the same as 'head' of 'connPending'. Since we just
             -- received r, we remove it from the pending list.
-            atomicModifyIORef' connPending $ \(_:rs) -> (rs, ())
+            atomicModifyIORef' connPending $ \rs -> (tail rs, ())
             -- We now expect one less reply from Redis. We don't count to
             -- negative, which would otherwise occur during pubsub.
             atomicModifyIORef' connPendingCnt $ \n -> (max 0 (n-1), ())

--- a/src/Database/Redis/Sentinel.hs
+++ b/src/Database/Redis/Sentinel.hs
@@ -46,6 +46,7 @@ import           Control.Exception     (Exception, IOException, evaluate, throwI
 import           Control.Monad
 import           Control.Monad.Catch   (Handler (..), MonadCatch, catches, throwM)
 import           Control.Monad.Except
+import           Control.Monad.IO.Class
 import           Data.ByteString       (ByteString)
 import qualified Data.ByteString       as BS
 import qualified Data.ByteString.Char8 as BS8

--- a/stack-8.6.yaml
+++ b/stack-8.6.yaml
@@ -1,1 +1,0 @@
-stack.yaml

--- a/stack-9.2.yaml
+++ b/stack-9.2.yaml
@@ -1,0 +1,8 @@
+resolver: nightly-2022-09-21
+packages:
+- '.'
+extra-deps:
+flags:
+  hedis:
+    dev: true
+extra-package-dbs: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-8.10.yaml
+stack-9.2.yaml


### PR DESCRIPTION
As discussed during Zurihac, please find PR that upstreams changes from the commit that we are using at the moment.