### PR TITLE
Support TOPK module.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 - Add support for additional Redis 6.2, 7.0, 8.0 commands (COPY, GETDEL/GETEX, HRANDFIELD, LMPOP/ZMPOP, SINTERCARD, FUNCTIONS, COMMAND LIST, etc.)
 - Add support for Redis vector set commands
 - Add support for RedisJSON commands including `jsonArrappend`, `jsonArrindex`, `jsonArrindexOpts`, `jsonArrlen`, `jsonArrlenAt`, `jsonArrinsert`, `jsonArrpop`, `jsonArrpopAt`, `jsonArrpopAtIndex`, `jsonArrtrim`, `jsonClear`, `jsonClearAt`, `jsonDebug`, `jsonDebugMemory`, `jsonDebugMemoryAt`, `jsonDel`, `jsonDelAt`, `jsonForget`, `jsonForgetAt`, `jsonGet`, `jsonGetOpts`, `jsonMerge`, `jsonMget`, `jsonMset`, `jsonNumincrby`, `jsonNummultby`, `jsonObjkeys`, `jsonObjkeysAt`, `jsonObjlen`, `jsonObjlenAt`, `jsonResp`, `jsonRespAt`, `jsonSet`, `jsonSetOpts`, `jsonStrappend`, `jsonStrappendAt`, `jsonToggle`, `jsonType`, and `jsonTypeAt`.
+- Add support for Top-K sketch commands: `topkAdd`, `topkCount`, `topkIncrby`, `topkInfo`, `topkList`, `topkListWithCount`, `topkReserve`, and `topkQuery`.
 
 ## 0.16.1
 

--- a/hedis.cabal
+++ b/hedis.cabal
@@ -90,6 +90,7 @@ library
                   , Database.Redis.ManualCommands.Cms
                   , Database.Redis.ManualCommands.FT
                   , Database.Redis.ManualCommands.JSON
+                  , Database.Redis.ManualCommands.Topk
                   , Database.Redis.Protocol
                   , Database.Redis.ProtocolPipelining
                   , Database.Redis.PubSub

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -75,6 +75,9 @@ module CF,
 -- ** Count-Min Sketches
 module Cms,
 
+-- ** Top-K
+module Topk,
+
 -- ** Redis Indexes
 module FT,
 
@@ -682,6 +685,7 @@ import Database.Redis.ManualCommands.CF as CF
 import Database.Redis.ManualCommands.Cms as Cms
 import Database.Redis.ManualCommands.FT as FT
 import Database.Redis.ManualCommands.JSON as JSON
+import Database.Redis.ManualCommands.Topk as Topk
 import Database.Redis.ManualCommands
 import Database.Redis.Types
 import Database.Redis.Core(sendRequest, RedisCtx)

--- a/src/Database/Redis/ManualCommands/Topk.hs
+++ b/src/Database/Redis/ManualCommands/Topk.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Database.Redis.ManualCommands.Topk where
+
+import Data.ByteString (ByteString)
+import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NE
+
+import Database.Redis.Core
+import Database.Redis.Protocol
+import Database.Redis.Types
+
+data TopkInfo = TopkInfo
+    { topkInfoK :: Integer
+      -- ^ Number of items kept in the Top-K list.
+    , topkInfoWidth :: Integer
+      -- ^ Number of counters in each array.
+    , topkInfoDepth :: Integer
+      -- ^ Number of counter arrays.
+    , topkInfoDecay :: Double
+      -- ^ Decay factor of the sketch.
+    } deriving (Show, Eq)
+
+instance RedisResult TopkInfo where
+    decode r = do
+        fields <- decode r :: Either Reply [(ByteString, Reply)]
+        topkInfoK <- decodeField "k" fields
+        topkInfoWidth <- decodeField "width" fields
+        topkInfoDepth <- decodeField "depth" fields
+        topkInfoDecay <- decodeField "decay" fields
+        pure TopkInfo{..}
+      where
+        decodeField key fields = maybe (Left r) decode (lookup key fields)
+
+-- |Adds one or more items to a Top-K sketch (<https://redis.io/commands/topk.add>).
+--
+-- Returns the items dropped from the sketch after each insertion, or 'Nothing' when no item was expelled.
+--
+-- $O(n \cdot d)$, where $n$ is the number of items and $d$ is the depth of the sketch.
+--
+-- Since RedisBloom 2.0.0
+topkAdd
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the Top-K sketch.
+    -> NonEmpty ByteString -- ^ Items to add.
+    -> m (f [Maybe ByteString])
+topkAdd key items = sendRequest $ ["TOPK.ADD", key] ++ NE.toList items
+
+-- |Returns the count for one or more items in a Top-K sketch (<https://redis.io/commands/topk.count>).
+--
+-- Returns @0@ for items that are not tracked by the sketch.
+--
+-- $O(n \cdot d)$, where $n$ is the number of items and $d$ is the depth of the sketch.
+--
+-- Since RedisBloom 2.0.0
+topkCount
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the Top-K sketch.
+    -> NonEmpty ByteString -- ^ Items to count.
+    -> m (f [Integer])
+topkCount key items = sendRequest $ ["TOPK.COUNT", key] ++ NE.toList items
+
+-- |Increments the count of one or more items by a configured amount (<https://redis.io/commands/topk.incrby>).
+--
+-- Returns the items dropped from the sketch after each increment, or 'Nothing' when no item was expelled.
+--
+-- $O(n \cdot d)$, where $n$ is the number of item-increment pairs and $d$ is the depth of the sketch.
+--
+-- Since RedisBloom 2.0.0
+topkIncrby
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the Top-K sketch.
+    -> NonEmpty (ByteString, Integer) -- ^ Item and increment pairs.
+    -> m (f [Maybe ByteString])
+topkIncrby key itemIncrements =
+    sendRequest $ ["TOPK.INCRBY", key] ++ concatMap encodePair (NE.toList itemIncrements)
+  where
+    encodePair (item, increment) = [item, encode increment]
+
+-- |Returns information about a Top-K sketch (<https://redis.io/commands/topk.info>).
+--
+-- $O(1)$
+--
+-- Since RedisBloom 2.0.0
+topkInfo
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the Top-K sketch.
+    -> m (f TopkInfo)
+topkInfo key = sendRequest ["TOPK.INFO", key]
+
+-- |Returns the items in a Top-K sketch (<https://redis.io/commands/topk.list>).
+--
+-- $O(k)$, where $k$ is the configured top-k size.
+--
+-- Since RedisBloom 2.0.0
+topkList
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the Top-K sketch.
+    -> m (f [ByteString])
+topkList key = sendRequest ["TOPK.LIST", key]
+
+-- |Returns the items in a Top-K sketch along with their approximated counts (<https://redis.io/commands/topk.list>).
+--
+-- $O(k)$, where $k$ is the configured top-k size.
+--
+-- Since RedisBloom 2.0.0
+topkListWithCount
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the Top-K sketch.
+    -> m (f [(ByteString, Integer)])
+topkListWithCount key = sendRequest ["TOPK.LIST", key, "WITHCOUNT"]
+
+-- |Creates an empty Top-K sketch (<https://redis.io/commands/topk.reserve>).
+--
+-- The sketch will fail to be created if the key already exists.
+--
+-- $O(1)$
+--
+-- Since RedisBloom 2.0.0
+topkReserve
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the Top-K sketch to create.
+    -> Integer -- ^ Number of items to keep in the sketch.
+    -> Integer -- ^ Number of counters in each array.
+    -> Integer -- ^ Number of counter arrays.
+    -> Double -- ^ Decay factor.
+    -> m (f Status)
+topkReserve key topk width depth decay =
+    sendRequest ["TOPK.RESERVE", key, encode topk, encode width, encode depth, encode decay]
+
+-- |Checks whether one or more items are present in a Top-K sketch (<https://redis.io/commands/topk.query>).
+--
+-- A 'False' value means the item is not currently one of the tracked heavy hitters.
+--
+-- $O(n \cdot d)$, where $n$ is the number of items and $d$ is the depth of the sketch.
+--
+-- Since RedisBloom 2.0.0
+topkQuery
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the Top-K sketch.
+    -> NonEmpty ByteString -- ^ Items to check.
+    -> m (f [Bool])
+topkQuery key items = sendRequest $ ["TOPK.QUERY", key] ++ NE.toList items

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -29,7 +29,7 @@ tests host port conn = map ($ conn) $ concat
     , testsClient, testsServer
     , [testScans, testSScan, testHScan, testZScan], [testZrangelex]
     , [testXAddRead, testXReadGroup, testXRange, testXpending, testXClaim, testXInfo, testXDel, testXTrim]
-    , [testBloomFilter, testCountMinSketch, testCuckooFilter, testJSON]
+    , [testBloomFilter, testCountMinSketch, testTopk, testCuckooFilter, testJSON]
     , testPubSubThreaded
       -- should always be run last as connection gets closed after it
     , [testQuit]

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -760,6 +760,40 @@ testCountMinSketch = testCase "count-min sketch" $ do
     cmsmergeWeighted "cms_weighted" (("cms1", 1) NE.:| [("cms3", 2)]) >>=? Ok
     cmsquery "cms_weighted" ("foo" NE.:| ["bar", "baz"]) >>=? [20, 5, 0]
 
+-- Top-K
+--
+testTopk :: Test
+testTopk = testCase "topk" $ do
+    topkReserve "topk1" 3 50 5 0.9 >>=? Ok
+    topkInfo "topk1" >>=? TopkInfo
+        { topkInfoK = 3
+        , topkInfoWidth = 50
+        , topkInfoDepth = 5
+        , topkInfoDecay = 0.9
+        }
+
+    topkAdd "topk1" ("foo" NE.:| ["bar", "baz"]) >>=? [Nothing, Nothing, Nothing]
+    topkQuery "topk1" ("foo" NE.:| ["bar", "missing"]) >>=? [True, True, False]
+    topkCount "topk1" ("foo" NE.:| ["bar", "missing"]) >>@? \counts ->
+        case counts of
+            [fooCount, barCount, 0] -> do
+                HUnit.assertBool "TOPK.COUNT foo should be positive" (fooCount > 0)
+                HUnit.assertBool "TOPK.COUNT bar should be positive" (barCount > 0)
+            _ -> HUnit.assertFailure $ "Unexpected TOPK.COUNT response: " ++ show counts
+
+    topkIncrby "topk1" (("foo", 10) NE.:| [("baz", 3), ("qux", 1)]) >>@? \results ->
+        HUnit.assertEqual "TOPK.INCRBY result length" 3 (length results)
+
+    topkList "topk1" >>@? \items -> do
+        HUnit.assertEqual "TOPK.LIST length" 3 (length items)
+        HUnit.assertBool "TOPK.LIST should include foo" ("foo" `elem` items)
+
+    topkListWithCount "topk1" >>@? \itemsWithCount -> do
+        HUnit.assertEqual "TOPK.LIST WITHCOUNT length" 3 (length itemsWithCount)
+        let itemKeys = map fst itemsWithCount
+        HUnit.assertBool "TOPK.LIST WITHCOUNT should include foo" ("foo" `elem` itemKeys)
+        HUnit.assertBool "TOPK.LIST WITHCOUNT counts should be positive" (all ((> 0) . snd) itemsWithCount)
+
 -- RedisJSON
 --
 testJSON :: Test


### PR DESCRIPTION
Add support for the TOPK extension.

Implemented with the help of AI and full manual review.

Model: GPT-5.4 (medium reasoning) via Codex
Prompt:
Support topk.* module. Introduce a new Database.Redis.ManualCommands.Topk module and reexport it.

In the module introduce commands:
TOPK.ADD, TOPK.COUNT, TOPK.INCRBY, TOPK.INFO, TOPK.LIST, TOPK.RESERVE, TOPK.QUERY

For each command:
1. Follow common patterns in project
2. Write complexity
3. Write function documentation headline
4. Link to the official command documentation
5. Write description
6. If command can return differrent types based on the arguments — make function for each type
7. If command can support optional arguments support Opt version
8. Reuse existing types and much as possible
9. Do not forget tests
10. Do not forget updating changelog