### PR TITLE
Support TDIGEST commands

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 - Add support for Redis vector set commands
 - Add support for RedisJSON commands including `jsonArrappend`, `jsonArrindex`, `jsonArrindexOpts`, `jsonArrlen`, `jsonArrlenAt`, `jsonArrinsert`, `jsonArrpop`, `jsonArrpopAt`, `jsonArrpopAtIndex`, `jsonArrtrim`, `jsonClear`, `jsonClearAt`, `jsonDebug`, `jsonDebugMemory`, `jsonDebugMemoryAt`, `jsonDel`, `jsonDelAt`, `jsonForget`, `jsonForgetAt`, `jsonGet`, `jsonGetOpts`, `jsonMerge`, `jsonMget`, `jsonMset`, `jsonNumincrby`, `jsonNummultby`, `jsonObjkeys`, `jsonObjkeysAt`, `jsonObjlen`, `jsonObjlenAt`, `jsonResp`, `jsonRespAt`, `jsonSet`, `jsonSetOpts`, `jsonStrappend`, `jsonStrappendAt`, `jsonToggle`, `jsonType`, and `jsonTypeAt`.
 - Add support for Top-K sketch commands: `topkAdd`, `topkCount`, `topkIncrby`, `topkInfo`, `topkList`, `topkListWithCount`, `topkReserve`, and `topkQuery`.
+- Add support for t-digest sketch commands: `tdigestAdd`, `tdigestByrank`, `tdigestByrevrank`, `tdigestCdf`, `tdigestCreate`, `tdigestCreateOpts`, `tdigestInfo`, `tdigestMax`, `tdigestMerge`, `tdigestMergeOpts`, `tdigestMin`, `tdigestQuantile`, `tdigestRank`, `tdigestReset`, `tdigestRevrank`, and `tdigestTrimmedMean`.
 
 ## 0.16.1
 

--- a/hedis.cabal
+++ b/hedis.cabal
@@ -90,6 +90,7 @@ library
                   , Database.Redis.ManualCommands.Cms
                   , Database.Redis.ManualCommands.FT
                   , Database.Redis.ManualCommands.JSON
+                  , Database.Redis.ManualCommands.Tdigest
                   , Database.Redis.ManualCommands.Topk
                   , Database.Redis.Protocol
                   , Database.Redis.ProtocolPipelining

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -78,6 +78,9 @@ module Cms,
 -- ** Top-K
 module Topk,
 
+-- ** T-Digest
+module Tdigest,
+
 -- ** Redis Indexes
 module FT,
 
@@ -685,6 +688,7 @@ import Database.Redis.ManualCommands.CF as CF
 import Database.Redis.ManualCommands.Cms as Cms
 import Database.Redis.ManualCommands.FT as FT
 import Database.Redis.ManualCommands.JSON as JSON
+import Database.Redis.ManualCommands.Tdigest as Tdigest
 import Database.Redis.ManualCommands.Topk as Topk
 import Database.Redis.ManualCommands
 import Database.Redis.Types

--- a/src/Database/Redis/ManualCommands/Tdigest.hs
+++ b/src/Database/Redis/ManualCommands/Tdigest.hs
@@ -1,0 +1,285 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Database.Redis.ManualCommands.Tdigest where
+
+import Data.ByteString (ByteString)
+import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NE
+import Data.Maybe (listToMaybe)
+
+import Database.Redis.Core
+import Database.Redis.Protocol
+import Database.Redis.Types
+
+data TDigestCreateOpts = TDigestCreateOpts
+    { tdigestCreateCompression :: Maybe Integer
+      -- ^ Compression parameter controlling accuracy and size.
+    } deriving (Show, Eq)
+
+defaultTDigestCreateOpts :: TDigestCreateOpts
+defaultTDigestCreateOpts = TDigestCreateOpts
+    { tdigestCreateCompression = Nothing
+    }
+
+data TDigestMergeOpts = TDigestMergeOpts
+    { tdigestMergeCompression :: Maybe Integer
+      -- ^ Compression parameter for the destination digest.
+    , tdigestMergeOverride :: Bool
+      -- ^ Overwrite the destination key if it already exists.
+    } deriving (Show, Eq)
+
+defaultTDigestMergeOpts :: TDigestMergeOpts
+defaultTDigestMergeOpts = TDigestMergeOpts
+    { tdigestMergeCompression = Nothing
+    , tdigestMergeOverride = False
+    }
+
+data TDigestInfo = TDigestInfo
+    { tdigestInfoCompression :: Integer
+      -- ^ Compression parameter of the digest.
+    , tdigestInfoCapacity :: Integer
+      -- ^ Allocated centroid capacity.
+    , tdigestInfoMergedNodes :: Integer
+      -- ^ Number of merged centroids.
+    , tdigestInfoUnmergedNodes :: Integer
+      -- ^ Number of pending unmerged centroids.
+    , tdigestInfoMergedWeight :: Integer
+      -- ^ Weight held by merged centroids.
+    , tdigestInfoUnmergedWeight :: Integer
+      -- ^ Weight held by pending unmerged centroids.
+    , tdigestInfoObservations :: Integer
+      -- ^ Total number of added observations.
+    , tdigestInfoTotalCompressions :: Integer
+      -- ^ Number of performed compression passes.
+    , tdigestInfoMemoryUsage :: Integer
+      -- ^ Memory usage in bytes.
+    } deriving (Show, Eq)
+
+instance RedisResult TDigestInfo where
+    decode r = do
+        fields <- decode r :: Either Reply [(ByteString, Integer)]
+        tdigestInfoCompression <- decodeField ["Compression", "compression"] fields
+        tdigestInfoCapacity <- decodeField ["Capacity", "capacity"] fields
+        tdigestInfoMergedNodes <- decodeField ["Merged nodes", "merged nodes"] fields
+        tdigestInfoUnmergedNodes <- decodeField ["Unmerged nodes", "unmerged nodes"] fields
+        tdigestInfoMergedWeight <- decodeField ["Merged weight", "merged weight"] fields
+        tdigestInfoUnmergedWeight <- decodeField ["Unmerged weight", "unmerged weight"] fields
+        tdigestInfoObservations <- decodeField ["Observations", "observations"] fields
+        tdigestInfoTotalCompressions <- decodeField ["Total compressions", "total compressions"] fields
+        tdigestInfoMemoryUsage <- decodeField ["Memory usage", "memory usage"] fields
+        pure TDigestInfo{..}
+      where
+        decodeField keys fields =
+            maybe (Left r) Right . listToMaybe $
+                [value | key <- keys, value <- maybeToList (lookup key fields)]
+
+        maybeToList = maybe [] pure
+
+tdigestCreateOptsToArgs :: TDigestCreateOpts -> [ByteString]
+tdigestCreateOptsToArgs TDigestCreateOpts{..} =
+    maybe [] (\compression -> ["COMPRESSION", encode compression]) tdigestCreateCompression
+
+tdigestMergeOptsToArgs :: TDigestMergeOpts -> [ByteString]
+tdigestMergeOptsToArgs TDigestMergeOpts{..} =
+    compressionArg ++ overrideArg
+  where
+    compressionArg = maybe [] (\compression -> ["COMPRESSION", encode compression]) tdigestMergeCompression
+    overrideArg = ["OVERRIDE" | tdigestMergeOverride]
+
+-- |Adds one or more observations to a t-digest sketch (<https://redis.io/commands/tdigest.add>).
+--
+-- $O(n \log k)$, where $n$ is the number of observations and $k$ is the compression parameter.
+--
+-- Since RedisBloom 2.4.0
+tdigestAdd
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the t-digest sketch.
+    -> NonEmpty Double -- ^ Observations to add.
+    -> m (f Status)
+tdigestAdd key values = sendRequest $ ["TDIGEST.ADD", key] ++ map encode (NE.toList values)
+
+-- |Returns observations by their ascending ranks from a t-digest sketch (<https://redis.io/commands/tdigest.byrank>).
+--
+-- $O(n \log k)$, where $n$ is the number of requested ranks and $k$ is the compression parameter.
+--
+-- Since RedisBloom 2.4.0
+tdigestByrank
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the t-digest sketch.
+    -> NonEmpty Integer -- ^ Requested ranks.
+    -> m (f [Double])
+tdigestByrank key ranks = sendRequest $ ["TDIGEST.BYRANK", key] ++ map encode (NE.toList ranks)
+
+-- |Returns observations by their descending ranks from a t-digest sketch (<https://redis.io/commands/tdigest.byrevrank>).
+--
+-- $O(n \log k)$, where $n$ is the number of requested reverse ranks and $k$ is the compression parameter.
+--
+-- Since RedisBloom 2.4.0
+tdigestByrevrank
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the t-digest sketch.
+    -> NonEmpty Integer -- ^ Requested reverse ranks.
+    -> m (f [Double])
+tdigestByrevrank key ranks = sendRequest $ ["TDIGEST.BYREVRANK", key] ++ map encode (NE.toList ranks)
+
+-- |Returns cumulative distribution estimates for one or more observations (<https://redis.io/commands/tdigest.cdf>).
+--
+-- $O(n \log k)$, where $n$ is the number of queried values and $k$ is the compression parameter.
+--
+-- Since RedisBloom 2.4.0
+tdigestCdf
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the t-digest sketch.
+    -> NonEmpty Double -- ^ Observations to query.
+    -> m (f [Double])
+tdigestCdf key values = sendRequest $ ["TDIGEST.CDF", key] ++ map encode (NE.toList values)
+
+-- |Creates an empty t-digest sketch (<https://redis.io/commands/tdigest.create>).
+--
+-- $O(1)$
+--
+-- Since RedisBloom 2.4.0
+tdigestCreate
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the t-digest sketch to create.
+    -> m (f Status)
+tdigestCreate key = tdigestCreateOpts key defaultTDigestCreateOpts
+
+-- |Creates an empty t-digest sketch (<https://redis.io/commands/tdigest.create>).
+--
+-- $O(1)$
+--
+-- Since RedisBloom 2.4.0
+tdigestCreateOpts
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the t-digest sketch to create.
+    -> TDigestCreateOpts -- ^ Creation options.
+    -> m (f Status)
+tdigestCreateOpts key opts =
+    sendRequest $ ["TDIGEST.CREATE", key] ++ tdigestCreateOptsToArgs opts
+
+-- |Returns information about a t-digest sketch (<https://redis.io/commands/tdigest.info>).
+--
+-- $O(1)$
+--
+-- Since RedisBloom 2.4.0
+tdigestInfo
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the t-digest sketch.
+    -> m (f TDigestInfo)
+tdigestInfo key = sendRequest ["TDIGEST.INFO", key]
+
+-- |Returns the maximum observation in a t-digest sketch (<https://redis.io/commands/tdigest.max>).
+--
+-- $O(1)$
+--
+-- Since RedisBloom 2.4.0
+tdigestMax
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the t-digest sketch.
+    -> m (f Double)
+tdigestMax key = sendRequest ["TDIGEST.MAX", key]
+
+-- |Merges multiple t-digest sketches into a destination sketch (<https://redis.io/commands/tdigest.merge>).
+--
+-- $O(n \cdot k)$, where $n$ is the number of source sketches and $k$ is the compression parameter.
+--
+-- Since RedisBloom 2.4.0
+tdigestMerge
+    :: (RedisCtx m f)
+    => ByteString -- ^ Destination key.
+    -> NonEmpty ByteString -- ^ Source sketch keys.
+    -> m (f Status)
+tdigestMerge destination sources =
+    tdigestMergeOpts destination sources defaultTDigestMergeOpts
+
+-- |Merges multiple t-digest sketches into a destination sketch (<https://redis.io/commands/tdigest.merge>).
+--
+-- $O(n \cdot k)$, where $n$ is the number of source sketches and $k$ is the compression parameter.
+--
+-- Since RedisBloom 2.4.0
+tdigestMergeOpts
+    :: (RedisCtx m f)
+    => ByteString -- ^ Destination key.
+    -> NonEmpty ByteString -- ^ Source sketch keys.
+    -> TDigestMergeOpts -- ^ Merge options.
+    -> m (f Status)
+tdigestMergeOpts destination sources opts =
+    sendRequest $
+        ["TDIGEST.MERGE", destination, encode (fromIntegral (NE.length sources) :: Integer)]
+            ++ NE.toList sources
+            ++ tdigestMergeOptsToArgs opts
+
+-- |Returns the minimum observation in a t-digest sketch (<https://redis.io/commands/tdigest.min>).
+--
+-- $O(1)$
+--
+-- Since RedisBloom 2.4.0
+tdigestMin
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the t-digest sketch.
+    -> m (f Double)
+tdigestMin key = sendRequest ["TDIGEST.MIN", key]
+
+-- |Returns quantile estimates for one or more quantiles (<https://redis.io/commands/tdigest.quantile>).
+--
+-- $O(n \log k)$, where $n$ is the number of quantiles and $k$ is the compression parameter.
+--
+-- Since RedisBloom 2.4.0
+tdigestQuantile
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the t-digest sketch.
+    -> NonEmpty Double -- ^ Quantiles to estimate.
+    -> m (f [Double])
+tdigestQuantile key quantiles =
+    sendRequest $ ["TDIGEST.QUANTILE", key] ++ map encode (NE.toList quantiles)
+
+-- |Returns ascending rank estimates for one or more observations (<https://redis.io/commands/tdigest.rank>).
+--
+-- $O(n \log k)$, where $n$ is the number of observations and $k$ is the compression parameter.
+--
+-- Since RedisBloom 2.4.0
+tdigestRank
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the t-digest sketch.
+    -> NonEmpty Double -- ^ Observations to rank.
+    -> m (f [Integer])
+tdigestRank key values = sendRequest $ ["TDIGEST.RANK", key] ++ map encode (NE.toList values)
+
+-- |Resets a t-digest sketch to its empty state (<https://redis.io/commands/tdigest.reset>).
+--
+-- $O(1)$
+--
+-- Since RedisBloom 2.4.0
+tdigestReset
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the t-digest sketch.
+    -> m (f Status)
+tdigestReset key = sendRequest ["TDIGEST.RESET", key]
+
+-- |Returns descending rank estimates for one or more observations (<https://redis.io/commands/tdigest.revrank>).
+--
+-- $O(n \log k)$, where $n$ is the number of observations and $k$ is the compression parameter.
+--
+-- Since RedisBloom 2.4.0
+tdigestRevrank
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the t-digest sketch.
+    -> NonEmpty Double -- ^ Observations to rank.
+    -> m (f [Integer])
+tdigestRevrank key values = sendRequest $ ["TDIGEST.REVRANK", key] ++ map encode (NE.toList values)
+
+-- |Returns the trimmed mean for observations within the provided quantile range (<https://redis.io/commands/tdigest.trimmed_mean>).
+--
+-- $O(\log k)$, where $k$ is the compression parameter.
+--
+-- Since RedisBloom 2.4.0
+tdigestTrimmedMean
+    :: (RedisCtx m f)
+    => ByteString -- ^ Key of the t-digest sketch.
+    -> Double -- ^ Lower quantile bound.
+    -> Double -- ^ Upper quantile bound.
+    -> m (f Double)
+tdigestTrimmedMean key lowCut highCut =
+    sendRequest ["TDIGEST.TRIMMED_MEAN", key, encode lowCut, encode highCut]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -29,7 +29,7 @@ tests host port conn = map ($ conn) $ concat
     , testsClient, testsServer
     , [testScans, testSScan, testHScan, testZScan], [testZrangelex]
     , [testXAddRead, testXReadGroup, testXRange, testXpending, testXClaim, testXInfo, testXDel, testXTrim]
-    , [testBloomFilter, testCountMinSketch, testTopk, testCuckooFilter, testJSON]
+    , [testBloomFilter, testCountMinSketch, testTopk, testTdigest, testCuckooFilter, testJSON]
     , testPubSubThreaded
       -- should always be run last as connection gets closed after it
     , [testQuit]

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -794,6 +794,73 @@ testTopk = testCase "topk" $ do
         HUnit.assertBool "TOPK.LIST WITHCOUNT should include foo" ("foo" `elem` itemKeys)
         HUnit.assertBool "TOPK.LIST WITHCOUNT counts should be positive" (all ((> 0) . snd) itemsWithCount)
 
+-- T-Digest
+--
+testTdigest :: Test
+testTdigest = testCase "tdigest" $ do
+    tdigestCreate "td1" >>=? Ok
+    tdigestAdd "td1" (1 NE.:| [2, 3, 4, 5]) >>=? Ok
+
+    tdigestMin "td1" >>=? 1
+    tdigestMax "td1" >>=? 5
+    tdigestByrank "td1" (0 NE.:| [2, 4]) >>=? [1, 3, 5]
+    tdigestByrevrank "td1" (0 NE.:| [2, 4]) >>=? [5, 3, 1]
+    tdigestQuantile "td1" (0.0 NE.:| [0.5, 1.0]) >>@? \values ->
+        case values of
+            [q0, q50, q100] -> do
+                HUnit.assertEqual "TDIGEST.QUANTILE 0" 1 q0
+                HUnit.assertBool "TDIGEST.QUANTILE 0.5 should be within range" (q50 >= 2 && q50 <= 4)
+                HUnit.assertEqual "TDIGEST.QUANTILE 1" 5 q100
+            _ -> HUnit.assertFailure $ "Unexpected TDIGEST.QUANTILE response: " ++ show values
+
+    tdigestCdf "td1" (1 NE.:| [3, 5]) >>@? \values ->
+        case values of
+            [cdf1, cdf3, cdf5] -> do
+                HUnit.assertBool "TDIGEST.CDF should be monotonic" (cdf1 <= cdf3 && cdf3 <= cdf5)
+                HUnit.assertBool "TDIGEST.CDF last value should be close to 1" (cdf5 >= 0.8)
+            _ -> HUnit.assertFailure $ "Unexpected TDIGEST.CDF response: " ++ show values
+
+    tdigestRank "td1" (1 NE.:| [3, 5]) >>@? \values ->
+        case values of
+            [r1, r3, r5] -> HUnit.assertBool "TDIGEST.RANK should be monotonic" (r1 <= r3 && r3 <= r5)
+            _ -> HUnit.assertFailure $ "Unexpected TDIGEST.RANK response: " ++ show values
+
+    tdigestRevrank "td1" (1 NE.:| [3, 5]) >>@? \values ->
+        case values of
+            [r1, r3, r5] -> HUnit.assertBool "TDIGEST.REVRANK should be monotonic descending" (r1 >= r3 && r3 >= r5)
+            _ -> HUnit.assertFailure $ "Unexpected TDIGEST.REVRANK response: " ++ show values
+
+    tdigestTrimmedMean "td1" 0.2 0.8 >>@? \value ->
+        HUnit.assertBool "TDIGEST.TRIMMED_MEAN should be within observed range" (value >= 1 && value <= 5)
+
+    tdigestInfo "td1" >>@? \TDigestInfo{..} -> do
+        HUnit.assertBool "TDIGEST.INFO compression should be positive" (tdigestInfoCompression > 0)
+        HUnit.assertBool "TDIGEST.INFO observations should reflect inserts" (tdigestInfoObservations >= 5)
+        HUnit.assertBool "TDIGEST.INFO memory usage should be positive" (tdigestInfoMemoryUsage > 0)
+
+    tdigestCreateOpts "td2" defaultTDigestCreateOpts
+        { tdigestCreateCompression = Just 200
+        } >>=? Ok
+    tdigestAdd "td2" (10 NE.:| [20, 30]) >>=? Ok
+
+    tdigestMerge "td_merged" ("td1" NE.:| ["td2"]) >>@? \status ->
+        HUnit.assertEqual "TDIGEST.MERGE status" Ok status
+    tdigestInfo "td_merged" >>@? \digestInfo ->
+        HUnit.assertBool "TDIGEST.MERGE should populate destination" (tdigestInfoObservations digestInfo >= 8)
+
+    tdigestCreate "td_override" >>=? Ok
+    tdigestMergeOpts "td_override" ("td1" NE.:| ["td2"]) defaultTDigestMergeOpts
+        { tdigestMergeCompression = Just 150
+        , tdigestMergeOverride = True
+        } >>=? Ok
+    tdigestInfo "td_override" >>@? \digestInfo -> do
+        150 HUnit.@=? tdigestInfoCompression digestInfo
+        HUnit.assertBool "TDIGEST.MERGE override should populate destination" (tdigestInfoObservations digestInfo >= 8)
+
+    tdigestReset "td1" >>=? Ok
+    tdigestInfo "td1" >>@? \digestInfo ->
+        HUnit.assertEqual "TDIGEST.RESET observations" 0 (tdigestInfoObservations digestInfo)
+
 -- RedisJSON
 --
 testJSON :: Test

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -803,8 +803,20 @@ testTdigest = testCase "tdigest" $ do
 
     tdigestMin "td1" >>=? 1
     tdigestMax "td1" >>=? 5
-    tdigestByrank "td1" (0 NE.:| [2, 4]) >>=? [1, 3, 5]
-    tdigestByrevrank "td1" (0 NE.:| [2, 4]) >>=? [5, 3, 1]
+    tdigestByrank "td1" (0 NE.:| [2, 4]) >>@? \values ->
+        case values of
+            [v0, v2, v4] -> do
+                HUnit.assertEqual "TDIGEST.BYRANK 0" 1 v0
+                HUnit.assertBool "TDIGEST.BYRANK 2 should be within range" (v2 >= 2 && v2 <= 4)
+                HUnit.assertEqual "TDIGEST.BYRANK 4" 5 v4
+            _ -> HUnit.assertFailure $ "Unexpected TDIGEST.BYRANK response: " ++ show values
+    tdigestByrevrank "td1" (0 NE.:| [2, 4]) >>@? \values ->
+        case values of
+            [v0, v2, v4] -> do
+                HUnit.assertEqual "TDIGEST.BYREVRANK 0" 5 v0
+                HUnit.assertBool "TDIGEST.BYREVRANK 2 should be within range" (v2 >= 2 && v2 <= 4)
+                HUnit.assertEqual "TDIGEST.BYREVRANK 4" 1 v4
+            _ -> HUnit.assertFailure $ "Unexpected TDIGEST.BYREVRANK response: " ++ show values
     tdigestQuantile "td1" (0.0 NE.:| [0.5, 1.0]) >>@? \values ->
         case values of
             [q0, q50, q100] -> do


### PR DESCRIPTION
Model: GPT-5.4 (medium reasoning) via Codex
Prompt:

Support tdigest.* module. Introduce a new Database.Redis.ManualCommands.Tdigest module and reexport it.

In the module introduce commands:
TDIGEST.ADD, TDIGEST.BYRANK, TDIGEST.BYREVRANK, TDIGEST.CDF, TDIGEST.CREATE, TDIGEST.INFO, TDIGEST.MAX, TDIGEST.MERGE, TDIGEST.MIN, TDIGEST.QUANTILE, TDIGEST.RANK, TDIGEST.RESET, TDIGEST.REVRANK, TDIGEST.TRIMMED_MEAN

For each command:
1. Follow common patterns in project
2. Write complexity
3. Write function documentation headline
4. Link to the official command documentation
5. Write description
6. If command can return differrent types based on the arguments — make function for each type
7. If command can support optional arguments support Opt version
8. Reuse existing types and much as possible
9. Do not forget tests
10. Do not forget updating changelog