### PR TITLE
Add wait commands

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@
 - Add support for Top-K sketch commands: `topkAdd`, `topkCount`, `topkIncrby`, `topkInfo`, `topkList`, `topkListWithCount`, `topkReserve`, and `topkQuery`.
 - Add support for t-digest sketch commands: `tdigestAdd`, `tdigestByrank`, `tdigestByrevrank`, `tdigestCdf`, `tdigestCreate`, `tdigestCreateOpts`, `tdigestInfo`, `tdigestMax`, `tdigestMerge`, `tdigestMergeOpts`, `tdigestMin`, `tdigestQuantile`, `tdigestRank`, `tdigestReset`, `tdigestRevrank`, and `tdigestTrimmedMean`.
 - Add support for RedisTimeSeries commands: `tsAdd`, `tsAddOpts`, `tsAlter`, `tsCreate`, `tsCreateOpts`, `tsCreaterule`, `tsCreateruleAlign`, `tsDecrby`, `tsDecrbyOpts`, `tsDel`, `tsDelrule`, `tsGet`, `tsGetOpts`, `tsIncrby`, `tsIncrbyOpts`, `tsInfo`, `tsInfoOpts`, `tsMadd`, `tsMget`, `tsMgetOpts`, `tsMrange`, `tsMrangeOpts`, `tsMrevrange`, `tsMrevrangeOpts`, `tsQueryindex`, `tsRange`, `tsRangeOpts`, `tsRevrange`, and `tsRevrangeOpts`.
+- Add support for wait commands: `wait` and `waitaof`.
 
 ## 0.16.1
 

--- a/hedis.cabal
+++ b/hedis.cabal
@@ -93,6 +93,7 @@ library
                   , Database.Redis.ManualCommands.Tdigest
                   , Database.Redis.ManualCommands.Ts
                   , Database.Redis.ManualCommands.Topk
+                  , Database.Redis.ManualCommands.Wait
                   , Database.Redis.Protocol
                   , Database.Redis.ProtocolPipelining
                   , Database.Redis.PubSub

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -64,7 +64,9 @@ sortStore,
 ttl,
 RedisType(..),
 getType,
-wait,
+
+-- ** Wait
+module Wait,
 
 -- ** Bloom Filters
 module BF,
@@ -694,6 +696,7 @@ import Database.Redis.ManualCommands.JSON as JSON
 import Database.Redis.ManualCommands.Tdigest as Tdigest
 import Database.Redis.ManualCommands.Ts as Ts
 import Database.Redis.ManualCommands.Topk as Topk
+import Database.Redis.ManualCommands.Wait as Wait
 import Database.Redis.ManualCommands
 import Database.Redis.Types
 import Database.Redis.Core(sendRequest, RedisCtx)
@@ -1199,15 +1202,6 @@ dbsize
     :: (RedisCtx m f)
     => m (f Integer)
 dbsize  = sendRequest ["DBSIZE"]
-
--- |Wait for the synchronous replication of all the write commands sent in the context of the current connection (<http://redis.io/commands/wait>).
--- Since Redis 3.0.0
-wait
-    :: (RedisCtx m f)
-    => Integer -- ^ numslaves
-    -> Integer -- ^ timeout
-    -> m (f Integer)
-wait numslaves timeout = sendRequest ["WAIT", encode numslaves, encode timeout]
 
 -- |Remove and get the first element in a list (<http://redis.io/commands/lpop>). Since Redis 1.0.0
 lpop

--- a/src/Database/Redis/ManualCommands/Wait.hs
+++ b/src/Database/Redis/ManualCommands/Wait.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Database.Redis.ManualCommands.Wait where
+
+import Database.Redis.Core
+import Database.Redis.Types
+
+data WaitAofResult = WaitAofResult
+    { waitAofLocal :: Integer
+      -- ^ Number of local Redis instances (0 or 1) that fsynced all preceding writes to AOF.
+    , waitAofReplicas :: Integer
+      -- ^ Number of replicas that fsynced all preceding writes to AOF.
+    } deriving (Show, Eq)
+
+instance RedisResult WaitAofResult where
+    decode response = do
+        (waitAofLocal, waitAofReplicas) <- decode response
+        pure WaitAofResult{..}
+
+-- |Wait for preceding writes to be acknowledged by a given number of replicas (<https://redis.io/commands/wait>).
+--
+-- Blocks until the asynchronous replication of all preceding write commands sent by the connection is completed.
+--
+-- $O(1)$
+--
+-- Since Redis 3.0.0
+wait
+    :: (RedisCtx m f)
+    => Integer -- ^ Number of replicas to wait for.
+    -> Integer -- ^ Maximum time to wait in milliseconds. @0@ means wait forever.
+    -> m (f Integer)
+wait numReplicas timeout =
+    sendRequest ["WAIT", encode numReplicas, encode timeout]
+
+-- |Wait for preceding writes to be fsynced to the append-only file locally and/or on replicas (<https://redis.io/commands/waitaof>).
+--
+-- Blocks until all of the preceding write commands sent by the connection are written to the append-only file of the master and/or replicas.
+--
+-- $O(1)$
+--
+-- Since Redis 7.2.0
+waitaof
+    :: (RedisCtx m f)
+    => Integer -- ^ Number of local Redis instances to wait for AOF fsync on (@0@ or @1@).
+    -> Integer -- ^ Number of replicas to wait for AOF fsync on.
+    -> Integer -- ^ Maximum time to wait in milliseconds. @0@ means wait forever.
+    -> m (f WaitAofResult)
+waitaof numLocal numReplicas timeout =
+    sendRequest ["WAITAOF", encode numLocal, encode numReplicas, encode timeout]

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -90,7 +90,7 @@ isHotkeysInactiveReply _ = False
 testsMisc :: [Test]
 testsMisc =
     [ testConstantSpacePipelining, testForceErrorReply, testPipelining
-    , testEvalReplies, testGeo
+    , testEvalReplies, testGeo, testWaitCommands
     ]
 
 testConstantSpacePipelining :: Test
@@ -195,6 +195,17 @@ testGeo = testCase "geo" $ do
   where
     assertApprox label expected actual =
         HUnit.assertBool label (abs (expected - actual) < 0.0001)
+
+testWaitCommands :: Test
+testWaitCommands = testCase "wait commands" $ do
+    set "wait:key" "value" >>=? Ok
+    wait 0 0 >>=? 0
+
+    waitaofResult <- waitaof 0 0 0
+    liftIO $ case waitaofResult of
+        Right result -> WaitAofResult 0 0 HUnit.@=? result
+        Left reply | isUnknownCommandReply reply -> pure ()
+        Left reply -> HUnit.assertFailure $ "Unexpected WAITAOF reply: " ++ show reply
 
 ------------------------------------------------------------------------------
 -- Keys


### PR DESCRIPTION
Model: GPT-5.4 (medium reasoning) via Codex
Prompt:

Support wait commands. Introduce a new Database.Redis.ManualCommands.module and reexport it.

In the module introduce commands:
WAIT, WAITAOF

For each command:
1. Follow common patterns in project
2. Write complexity
3. Write function documentation headline
4. Link to the official command documentation
5. Write description
6. If command can return differrent types based on the arguments — make function for each type
7. If command can support optional arguments support Opt version
8. Reuse existing types and much as possible
9. Do not forget tests
10. Do not forget updating changelog